### PR TITLE
Pull nuget api key from secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: 'Package and Publish'
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: >
           ./PackAndPublish
-          -NuGetApiKey:${{ secrets.NUGET_API_KEY }}
           -Publish
           -Beta:$${{ github.event.inputs.publish_beta }}
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      nuget_api_key:
-        description: 'NuGet API key'
-        required: true
       publish_beta:
         description: 'Publish as beta'
         required: false
@@ -21,7 +18,7 @@ jobs:
       - name: 'Package and Publish'
         run: >
           ./PackAndPublish
-          -NuGetApiKey:${{ github.event.inputs.nuget_api_key }}
+          -NuGetApiKey:${{ secrets.NUGET_API_KEY }}
           -Publish
           -Beta:$${{ github.event.inputs.publish_beta }}
         shell: pwsh

--- a/scripts/PackAndPublish.ps1
+++ b/scripts/PackAndPublish.ps1
@@ -37,8 +37,11 @@ if ($Version.Length -eq 0) {
 }
 
 if ($Publish -and $NuGetApiKey.Length -eq 0) {
-  Write-Error "Please provide a NuGet API key for publishing the package"
-  exit 1
+  $NuGetApiKey = $Env:NUGET_API_KEY
+  if ($NuGetApiKey.Length -eq 0) {
+    Write-Error "Please provide a NuGet API key for publishing the package"
+    exit 1
+  }
 }
 
 if ($Beta) {


### PR DESCRIPTION
Store the NuGet api key as a GitHub secret and pass to the `PackAndPublish` script as an environment variable rather than manual input. Keep the option to pass the key as an argument for local publishing.