### PR TITLE
Add support for interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Static classes
 - Static properties
 - Properties with default values
+- Generating interface source code
 
 ### Changed
 
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Changed the publish script to look for an env var if nuget api key not provided as an argument
 - Structure build logic - keep builders locally, build when explicitly requested
 - Improved validation during the build of a structure
+- Validate the access members of namespace members (no private/protected [internal] classes/interfaces!)
+- Use C# 9.0
 
 ## [0.0.1] - 2020-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structure build logic - keep builders locally, build when explicitly requested
 - Improved validation during the build of a structure
 - Validate the access members of namespace members (no private/protected [internal] classes/interfaces!)
-- Use C# 9.0
 
 ## [0.0.1] - 2020-09-20
 

--- a/src/SharpCode.Test/InterfaceBuilderTests.cs
+++ b/src/SharpCode.Test/InterfaceBuilderTests.cs
@@ -1,0 +1,152 @@
+using NUnit.Framework;
+
+namespace SharpCode.Test
+{
+    [TestFixture]
+    public class InterfaceBuilderTests
+    {
+        [Test]
+        public void CreatingInterface_WithoutRequiredSettings_Throws()
+        {
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateInterface().ToSourceCode(),
+                "Generating the source code for an interface without a name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateInterface().WithName(null).ToSourceCode(),
+                "Generating the source code for an interface with null as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateInterface().WithName(string.Empty).ToSourceCode(),
+                "Generating the source code for an interface with an empty string as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateInterface().WithName("   ").ToSourceCode(),
+                "Generating the source code for an interface with whitespace as name should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingInterface_ValidatesPropertiesDefinitions()
+        {
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateInterface("ITest")
+                    .WithProperty(Code.CreateProperty("int", "Test").WithDefaultValue("42"))
+                    .ToSourceCode(),
+                "Generating the source code for an interface with a property that has a default value should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateInterface("ITest")
+                    .WithProperty(Code.CreateProperty("int", "Test").WithGetter("_value"))
+                    .ToSourceCode(),
+                "Generating the source code for an interface with a property that has " +
+                    "a non auto implemented getter should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateInterface("ITest")
+                    .WithProperty(Code.CreateProperty("int", "Test").WithSetter("_value = value"))
+                    .ToSourceCode(),
+                "Generating the source code for an interface with a property that has " +
+                    "a non auto implemented setter should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateInterface("ITest")
+                    .WithProperty(Code.CreateProperty("int", "Test").WithoutGetter().WithoutSetter())
+                    .ToSourceCode(),
+                "Generating the source code for an interface with a property that does not have " +
+                    "a getter nor a setter should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingInterface_Works()
+        {
+            var generatedCode = Code.CreateInterface("ITest").ToSourceCode().WithUnixEOL();
+
+            var expectedCode = @"
+public interface ITest
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingInterface_WithImplementedInterfaces_Works()
+        {
+            var generatedCode = Code.CreateInterface("ITest")
+                .WithImplementedInterface("IHaveTests")
+                .WithImplementedInterface("IFailNot")
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface ITest : IHaveTests, IFailNot
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingInterface_WithDifferentAccessModifiers_Works()
+        {
+            var expectedCode = @"
+{access-modifier} interface ITest
+{
+}
+            ".WithUnixEOL();
+
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", string.Empty).Trim(),
+                Code.CreateInterface("ITest", AccessModifier.None).ToSourceCode().WithUnixEOL());
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", "private").Trim(),
+                Code.CreateInterface("ITest", AccessModifier.Private).ToSourceCode().WithUnixEOL());
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", "private internal").Trim(),
+                Code.CreateInterface("ITest", AccessModifier.PrivateInternal).ToSourceCode().WithUnixEOL());
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", "internal").Trim(),
+                Code.CreateInterface("ITest", AccessModifier.Internal).ToSourceCode().WithUnixEOL());
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", "protected").Trim(),
+                Code.CreateInterface("ITest", AccessModifier.Protected).ToSourceCode().WithUnixEOL());
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", "protected internal").Trim(),
+                Code.CreateInterface("ITest", AccessModifier.ProtectedInternal).ToSourceCode().WithUnixEOL());
+            Assert.AreEqual(
+                expectedCode.Replace("{access-modifier}", "public").Trim(),
+                Code.CreateInterface("ITest", AccessModifier.Public).ToSourceCode().WithUnixEOL());
+        }
+
+        [Test]
+        public void CreatingInterface_WithProperties_Works()
+        {
+            var generatedCode = Code.CreateInterface("ITest")
+                .WithProperty(Code.CreateProperty("int", "Number"))
+                .WithProperty(Code.CreateProperty("string", "Stringy"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface ITest
+{
+    int Number
+    {
+        get;
+        set;
+    }
+
+    string Stringy
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+    }
+}

--- a/src/SharpCode.Test/NamespaceBuilderTests.cs
+++ b/src/SharpCode.Test/NamespaceBuilderTests.cs
@@ -186,5 +186,97 @@ namespace Vehicles
                 () => Code.CreateNamespace().WithName("  ").ToSourceCode(),
                 "Generating the source code for a namespace with a whitespace name should throw an exception.");
         }
+
+        [Test]
+        public void CreatingNamespace_ValidatesMembersAccessModifiers()
+        {
+            // -- Classes
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithClass(Code.CreateClass("Test", AccessModifier.Private))
+                    .ToSourceCode(),
+                "Generating the source code for a private class inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithClass(Code.CreateClass("Test", AccessModifier.PrivateInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a private internal class inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithClass(Code.CreateClass("Test", AccessModifier.Protected))
+                    .ToSourceCode(),
+                "Generating the source code for a protected class inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithClass(Code.CreateClass("Test", AccessModifier.ProtectedInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a protected internal class inside a namespace should throw an exception.");
+
+            // -- Interfaces
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithInterface(Code.CreateInterface("ITest", AccessModifier.Private))
+                    .ToSourceCode(),
+                "Generating the source code for a private interface inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithInterface(Code.CreateInterface("ITest", AccessModifier.PrivateInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a private internal interface inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithInterface(Code.CreateInterface("ITest", AccessModifier.Protected))
+                    .ToSourceCode(),
+                "Generating the source code for a protected interface inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithInterface(Code.CreateInterface("ITest", AccessModifier.ProtectedInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a protected internal interface inside a namespace should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingNamespace_WithInterfaces_Works()
+        {
+            var generatedCode = Code.CreateNamespace("GeneratedGoodies")
+                .WithInterface(Code.CreateInterface("IHaveGoodies")
+                    .WithProperty(Code.CreateProperty("int", "Count")))
+                .WithInterface(Code.CreateInterface("IHaveHiddenGoodies", AccessModifier.Internal)
+                    .WithImplementedInterface("IHaveGoodies")
+                    .WithProperty(Code.CreateProperty("int", "HiddenCount")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+namespace GeneratedGoodies
+{
+    public interface IHaveGoodies
+    {
+        int Count
+        {
+            get;
+            set;
+        }
+    }
+
+    internal interface IHaveHiddenGoodies : IHaveGoodies
+    {
+        int HiddenCount
+        {
+            get;
+            set;
+        }
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
     }
 }

--- a/src/SharpCode.Test/SharpCode.Test.csproj
+++ b/src/SharpCode.Test/SharpCode.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/SharpCode.Test/SharpCode.Test.csproj
+++ b/src/SharpCode.Test/SharpCode.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/SharpCode/Code.cs
+++ b/src/SharpCode/Code.cs
@@ -62,6 +62,14 @@ namespace SharpCode
             return new ConstructorBuilder();
         }
 
+        public static InterfaceBuilder CreateInterface() =>
+            new InterfaceBuilder();
+
+        public static InterfaceBuilder CreateInterface(
+            string name,
+            AccessModifier accessModifier = AccessModifier.Public) =>
+            new InterfaceBuilder(name, accessModifier);
+
         public static NamespaceBuilder CreateNamespace()
         {
             return new NamespaceBuilder();

--- a/src/SharpCode/Extensions.cs
+++ b/src/SharpCode/Extensions.cs
@@ -141,6 +141,26 @@ namespace SharpCode
             return formatted ? raw.FormatSourceCode() : raw;
         }
 
+        public static string ToSourceCode(this Interface data, bool formatted)
+        {
+            const string Template = @"
+{access-modifier} interface {name}{inheritance}
+{
+    {properties}
+}
+            ";
+
+            var raw = Template
+                .Replace("{access-modifier}", data.AccessModifier.ToSourceCode())
+                .Replace("{name}", data.Name)
+                .Replace("{inheritance}", data.ImplementedInterfaces.Any()
+                    ? $": {data.ImplementedInterfaces.Join(", ")}"
+                    : string.Empty)
+                .Replace("{properties}", data.Properties.Select(item => item.ToSourceCode(false)).Join("\n"));
+
+            return formatted ? raw.FormatSourceCode() : raw;
+        }
+
         public static string ToSourceCode(this Namespace data, bool formatted)
         {
             const string Template = @"
@@ -148,6 +168,7 @@ namespace SharpCode
 
 namespace {name}
 {
+    {interfaces}
     {classes}
 }
             ";
@@ -155,6 +176,7 @@ namespace {name}
             var raw = Template
                 .Replace("{name}", data.Name)
                 .Replace("{usings}", data.Usings.Select(item => $"using {item};").Join("\n"))
+                .Replace("{interfaces}", data.Interfaces.Select(item => item.ToSourceCode(false)).Join("\n"))
                 .Replace("{classes}", data.Classes.Select(item => item.ToSourceCode(false)).Join("\n"));
 
             return formatted ? raw.FormatSourceCode() : raw;

--- a/src/SharpCode/InterfaceBuilder.cs
+++ b/src/SharpCode/InterfaceBuilder.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SharpCode
+{
+    public class InterfaceBuilder
+    {
+        private readonly Interface _interface = new Interface();
+        private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
+
+        internal InterfaceBuilder() { }
+
+        internal InterfaceBuilder(string name, AccessModifier accessModifier)
+        {
+            _interface.Name = name;
+            _interface.AccessModifier = accessModifier;
+        }
+
+        /// <summary>
+        /// Sets the access modifier of the interface being built.
+        /// </summary>
+        public InterfaceBuilder WithAccessModifier(AccessModifier accessModifier)
+        {
+            _interface.AccessModifier = accessModifier;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name of the interface being built.
+        /// </summary>
+        public InterfaceBuilder WithName(string name)
+        {
+            _interface.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a property to the interface being built.
+        /// </summary>
+        public InterfaceBuilder WithProperty(PropertyBuilder builder)
+        {
+            _properties.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of properties to the interface being built.
+        /// </summary>
+        public InterfaceBuilder WithProperties(params PropertyBuilder[] builders)
+        {
+            _properties.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an interface to the list of interfaces that the interface being built implements.
+        /// </summary>
+        public InterfaceBuilder WithImplementedInterface(string name)
+        {
+            _interface.ImplementedInterfaces.Add(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the source code of the built interface.
+        /// </summary>
+        /// <param name="formatted">
+        /// Indicates whether to format the source code.
+        /// </param>
+        public string ToSourceCode(bool formatted = true) =>
+            Build().ToSourceCode(formatted);
+
+        /// <summary>
+        /// Returns the source code of the built interface.
+        /// </summary>
+        public override string ToString() =>
+            ToSourceCode();
+
+        internal Interface Build()
+        {
+            if (string.IsNullOrWhiteSpace(_interface.Name))
+            {
+                throw new MissingBuilderSettingException(
+                    "Providing the name of the interface is required when building an interface.");
+            }
+
+            _interface.Properties.AddRange(
+                _properties.Select(builder => builder
+                    .WithAccessModifier(AccessModifier.None)
+                    .Build()));
+            if (_interface.Properties.Any(prop => prop.DefaultValue.HasValue))
+            {
+                throw new SyntaxException("Interface properties cannot have a default value. (CS8053)");
+            }
+            else if (_interface.Properties.Any(prop => !prop.Getter.HasValue && !prop.Setter.HasValue))
+            {
+                throw new SyntaxException("Interface properties should have at least a getter or a setter.");
+            }
+            else if (_interface.Properties.Any(prop => prop.Getter.Exists(expr => !string.IsNullOrWhiteSpace(expr))))
+            {
+                throw new SyntaxException("Interface properties can only define an auto implemented getter.");
+            }
+            else if (_interface.Properties.Any(prop => prop.Setter.Exists(expr => !string.IsNullOrWhiteSpace(expr))))
+            {
+                throw new SyntaxException("Interface properties can only define an auto implemented setter.");
+            }
+
+            return _interface;
+        }
+    }
+}

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -61,10 +61,19 @@ namespace SharpCode
         public List<Constructor> Constructors { get; } = new List<Constructor>();
     }
 
+    internal class Interface
+    {
+        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public string? Name { get; set; }
+        public List<string> ImplementedInterfaces { get; } = new List<string>();
+        public List<Property> Properties { get; } = new List<Property>();
+    }
+
     internal class Namespace
     {
         public string? Name { get; set; }
         public List<string> Usings { get; } = new List<string>();
         public List<Class> Classes { get; } = new List<Class>();
+        public List<Interface> Interfaces { get; } = new List<Interface>();
     }
 }


### PR DESCRIPTION
## Summary

- generate source code for interfaces
- more validation for namespaces
   - check members access modifiers
- updated changelog

## Interfaces are now supported

```csharp
Code.CreateInterface("IHaveUpdates").WithImplementedInterface("ICountable").ToSourceCode();
// yields
public interface IHaveUpdates : ICountable
{
}
```

## More namespace validation

When building a namespace the access modifiers of members are being validated.

```csharp
namespace Example
{
    class Class { } // ✔
    internal class Class { } // ✔
    public class Class { } // ✔
    private class Class { } // ❌ SyntaxException
    private internal class Class { } // ❌ SyntaxException
    protected class Class { } // ❌ SyntaxException
    protected internal class Class { } // ❌ SyntaxException

    interface Interface { } // ✔
    internal interface Interface { } // ✔
    public interface Interface { } // ✔
    private interface Interface { } // ❌ SyntaxException
    private internal interface Interface { } // ❌ SyntaxException
    protected interface Interface { } // ❌ SyntaxException
    protected internal interface Interface { } // ❌ SyntaxException
}
```