### PR TITLE
Add support for enums

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,7 @@ dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:error
 dotnet_style_prefer_conditional_expression_over_assignment = true:warning
-dotnet_style_prefer_conditional_expression_over_return = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 
 # Null-checking preferences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Automated GitHub releases from the release action
+- Support for enums generation
+- Support for various enum members - with implicit and/or explicit values, flags
 
 ## [0.1.0] - 2020-09-26
 

--- a/src/SharpCode.Test/.editorconfig
+++ b/src/SharpCode.Test/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+
+# Unused value preferences
+# Suppress, otherwise every Assert.Throws<T>() must use the discard variable
+csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/src/SharpCode.Test/EnumBuilderTests.cs
+++ b/src/SharpCode.Test/EnumBuilderTests.cs
@@ -1,0 +1,161 @@
+using NUnit.Framework;
+
+namespace SharpCode.Test
+{
+    [TestFixture]
+    public class EnumBuilderTests
+    {
+        [Test]
+        public void CreatingEnum_Works()
+        {
+            var generatedCode = Code.CreateEnum()
+                .WithAccessModifier(AccessModifier.Internal)
+                .WithName("UserStatus")
+                .WithMember(Code.CreateEnumMember("Inactive"))
+                .WithMember(Code.CreateEnumMember("Active"))
+                .WithMembers(
+                    Code.CreateEnumMember("Blocked"),
+                    Code.CreateEnumMember("NotConfirmed"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+internal enum UserStatus
+{
+    Inactive,
+    Active,
+    Blocked,
+    NotConfirmed,
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingFlagsEnum_Works()
+        {
+            var generatedCode = Code.CreateEnum()
+                .MakeFlagsEnum()
+                .WithAccessModifier(AccessModifier.Public)
+                .WithName("Colors")
+                .WithMember(Code.CreateEnumMember("Red"))
+                .WithMembers(
+                    Code.CreateEnumMember("Green"),
+                    Code.CreateEnumMember("Blue"),
+                    Code.CreateEnumMember("Orange"),
+                    Code.CreateEnumMember("Black"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+[System.Flags]
+public enum Colors
+{
+    Red = 0,
+    Green = 1,
+    Blue = 2,
+    Orange = 4,
+    Black = 8,
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingEnum_WithCustomValues()
+        {
+            var generatedCode = Code.CreateEnum(name: "Color")
+                .WithMember(Code.CreateEnumMember("None", 0))
+                .WithMember(Code.CreateEnumMember("Red", 100))
+                .WithMember(Code.CreateEnumMember("Green", 222))
+                .WithMember(Code.CreateEnumMember("Blue", 404))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public enum Color
+{
+    None = 0,
+    Red = 100,
+    Green = 222,
+    Blue = 404,
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingFlagsEnum_WithExplicitMemberValues_DoesNotGenerateValues()
+        {
+            var generatedCode = Code.CreateEnum(name: "Storage")
+                .WithMember(Code.CreateEnumMember("None", 0))
+                .WithMember(Code.CreateEnumMember("HardDrive", 1))
+                .WithMember(Code.CreateEnumMember("SolidStateDrive", 2))
+                .WithMember(Code.CreateEnumMember("FlashStick"))
+                .WithMember(Code.CreateEnumMember("ExternalHardDrive", 4))
+                .MakeFlagsEnum()
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+[System.Flags]
+public enum Storage
+{
+    None = 0,
+    HardDrive = 1,
+    SolidStateDrive = 2,
+    FlashStick,
+    ExternalHardDrive = 4,
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingEnum_WithMissingRequiredSettings_Throws()
+        {
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum().ToSourceCode(),
+                "Generating the source code for an enum without setting the name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum(name: null).ToSourceCode(),
+                "Generating the source for an enum with null as a name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum().WithName(null).ToSourceCode(),
+                "Generating the source for an enum with null as a name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum(name: string.Empty).ToSourceCode(),
+                "Generating the source for an enum with an empty name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum().WithName(string.Empty).ToSourceCode(),
+                "Generating the source for an enum with an empty name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum(name: "  ").ToSourceCode(),
+                "Generating the source for an enum with a whitespace name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnum().WithName("  ").ToSourceCode(),
+                "Generating the source for an enum with a whitespace name should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingEnum_WithDuplicateMembers_Throws()
+        {
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateEnum(name: "Test").WithMembers(
+                    Code.CreateEnumMember("Duplicate"),
+                    Code.CreateEnumMember("Duplicate"))
+                    .ToSourceCode(),
+                "Generating the source code for an enum with duplicate values should throw an exception.");
+        }
+    }
+}

--- a/src/SharpCode.Test/NamespaceBuilderTests.cs
+++ b/src/SharpCode.Test/NamespaceBuilderTests.cs
@@ -159,6 +159,70 @@ namespace Vehicles
         }
 
         [Test]
+        public void CreatingNamespace_WithEnum_Works()
+        {
+            var generatedCode = Code.CreateNamespace(name: "GeneratedCode")
+                .WithEnum(Code.CreateEnum(name: "Level")
+                    .WithMembers(
+                        Code.CreateEnumMember("Low"),
+                        Code.CreateEnumMember("Medium"),
+                        Code.CreateEnumMember("High")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+namespace GeneratedCode
+{
+    public enum Level
+    {
+        Low,
+        Medium,
+        High,
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingNamespace_WithFlagsEnum_Works()
+        {
+            var generatedCode = Code.CreateNamespace(name: "GeneratedCode")
+                .WithEnum(Code.CreateEnum(name: "Level")
+                    .WithMembers(
+                        Code.CreateEnumMember("Off"),
+                        Code.CreateEnumMember("VeryLow"),
+                        Code.CreateEnumMember("Low"),
+                        Code.CreateEnumMember("Medium"),
+                        Code.CreateEnumMember("High"),
+                        Code.CreateEnumMember("ExtraHigh"),
+                        Code.CreateEnumMember("Max"))
+                    .MakeFlagsEnum())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+namespace GeneratedCode
+{
+    [System.Flags]
+    public enum Level
+    {
+        Off = 0,
+        VeryLow = 1,
+        Low = 2,
+        Medium = 4,
+        High = 8,
+        ExtraHigh = 16,
+        Max = 32,
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
         public void CreateClass_Throws_WhenRequiredSettingsNotProvided()
         {
             Assert.Throws<MissingBuilderSettingException>(
@@ -239,6 +303,31 @@ namespace Vehicles
                     .WithInterface(Code.CreateInterface("ITest", AccessModifier.ProtectedInternal))
                     .ToSourceCode(),
                 "Generating the source code for a protected internal interface inside a namespace should throw an exception.");
+
+            // -- Enums
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithEnum(Code.CreateEnum("Test", AccessModifier.Private))
+                    .ToSourceCode(),
+                "Generating the source code for a private enum inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithEnum(Code.CreateEnum("Test", AccessModifier.PrivateInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a private internal enum inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithEnum(Code.CreateEnum("Test", AccessModifier.Protected))
+                    .ToSourceCode(),
+                "Generating the source code for a protected enum inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithEnum(Code.CreateEnum("Test", AccessModifier.ProtectedInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a protected internal enum inside a namespace should throw an exception.");
         }
 
         [Test]

--- a/src/SharpCode/Code.cs
+++ b/src/SharpCode/Code.cs
@@ -1,4 +1,5 @@
 using System;
+using Optional;
 
 namespace SharpCode
 {
@@ -22,6 +23,49 @@ namespace SharpCode
         /// </param>
         public static NamespaceBuilder CreateNamespace(string name) =>
             new NamespaceBuilder(name);
+
+        /// <summary>
+        /// Creates a new <see cref="EnumBuilder"/> instance for building enums.
+        /// </summary>
+        public static EnumBuilder CreateEnum() =>
+            new EnumBuilder();
+
+        /// <summary>
+        /// Creates a new pre-configured <see cref="EnumBuilder"/> instance for building enums. Configures the
+        /// <see cref="EnumBuilder"/> instance with the specified <paramref name="name"/> and
+        /// <paramref name="accessModifier"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the enum.
+        /// </param>
+        /// <param name="accessModifier">
+        /// The access modifier of the enum.
+        /// </param>
+        public static EnumBuilder CreateEnum(string name, AccessModifier accessModifier = AccessModifier.Public) =>
+            new EnumBuilder(name, accessModifier);
+
+        /// <summary>
+        /// Creates a new <see cref="EnumMemberBuilder"/> instance for building enum members.
+        /// </summary>
+        public static EnumMemberBuilder CreateEnumMember() =>
+            new EnumMemberBuilder();
+
+        /// <summary>
+        /// Creates a new pre-configured <see cref="EnumMemberBuilder"/> instance for building enum members. Configures
+        /// the <see cref="EnumMemberBuilder"/> instance with the specified <paramref name="name"/> and
+        /// <paramref name="value"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the enum member.
+        /// </param>
+        /// <param name="value">
+        /// Optional. Explicitly specifies the value of the enum member. <b>Note</b> that if the enum is marked as
+        /// flags, via <see cref="EnumBuilder.MakeFlagsEnum(bool)"/>, you need to explicitly provide the values of all
+        /// members to ensure correct functionality. Flags enums for which no member has an explicit value will
+        /// auto-generate appropriate values for each member.
+        /// </param>
+        public static EnumMemberBuilder CreateEnumMember(string name, int? value = null) =>
+            new EnumMemberBuilder(name, value.ToOption());
 
         /// <summary>
         /// Creates a new <see cref="InterfaceBuilder"/> instance for building interface structures.

--- a/src/SharpCode/EnumBuilder.cs
+++ b/src/SharpCode/EnumBuilder.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Optional;
+using Optional.Collections;
+
+namespace SharpCode
+{
+    /// <summary>
+    /// Provides functionalty for building enum structures. <see cref="EnumBuilder"/> instances are <b>not</b>
+    /// immutable.
+    /// </summary>
+    public class EnumBuilder
+    {
+        private readonly Enumeration _enumeration = new Enumeration();
+        private readonly List<EnumMemberBuilder> _members = new List<EnumMemberBuilder>();
+
+        internal EnumBuilder() { }
+
+        internal EnumBuilder(string name, AccessModifier accessModifier)
+        {
+            _enumeration.Name = name;
+            _enumeration.AccessModifier = accessModifier;
+        }
+
+        /// <summary>
+        /// Sets the access modifier of the enum being built.
+        /// </summary>
+        public EnumBuilder WithAccessModifier(AccessModifier accessModifier)
+        {
+            _enumeration.AccessModifier = accessModifier;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name of the enum being built.
+        /// </summary>
+        public EnumBuilder WithName(string name)
+        {
+            _enumeration.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a member to the enum being built.
+        /// </summary>
+        public EnumBuilder WithMember(EnumMemberBuilder builder)
+        {
+            _members.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of members to the enum being built.
+        /// </summary>
+        public EnumBuilder WithMembers(params EnumMemberBuilder[] builders)
+        {
+            _members.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of members to the enum being built.
+        /// </summary>
+        public EnumBuilder WithMembers(IEnumerable<EnumMemberBuilder> builders)
+        {
+            _members.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies whether the enum being built represents a set of flags or not. A flags enum will be marked with
+        /// the <see cref="FlagsAttribute"/> in the generated source code. The members of a flags enum will be assigned
+        /// appropriate, auto-generated values. <b>Note</b> that explicitly set values will be overwritten.
+        /// </summary>
+        /// <param name="makeFlagsEnum">
+        /// Indicates whether the enum represents a set of flags.
+        /// </param>
+        public EnumBuilder MakeFlagsEnum(bool makeFlagsEnum = true)
+        {
+            _enumeration.IsFlag = makeFlagsEnum;
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the source code of the built enum.
+        /// </summary>
+        /// <param name="formatted">
+        /// Indicates whether to format the source code.
+        /// </param>
+        public string ToSourceCode(bool formatted = true) =>
+            Build().ToSourceCode(formatted);
+
+        /// <summary>
+        /// Returns the source code of the built enum.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() =>
+            ToSourceCode();
+
+        internal Enumeration Build()
+        {
+            if (string.IsNullOrWhiteSpace(_enumeration.Name))
+            {
+                throw new MissingBuilderSettingException(
+                    "Providing the name of the enum is required when building an enum.");
+            }
+
+            _enumeration.Members.AddRange(_members.Select(x => x.Build()));
+            _enumeration.Members
+                .GroupBy(x => x.Name)
+                .Where(x => x.AtLeast(2))
+                .Select(x => x.Key)
+                .FirstOrNone()
+                .MatchSome(duplicateMemberName => throw new SyntaxException(
+                    $"The enum '{_enumeration.Name}' already contains a definition for '{duplicateMemberName}'."));
+
+
+            if (_enumeration.IsFlag && _enumeration.Members.All(x => !x.Value.HasValue))
+            {
+                for (var i = 0; i < _enumeration.Members.Count; i++)
+                {
+                    _enumeration.Members[i].Value = Option.Some(i == 0 ? 0 : (int)Math.Pow(2, i - 1));
+                }
+            }
+
+            return _enumeration;
+        }
+    }
+}

--- a/src/SharpCode/EnumMemberBuilder.cs
+++ b/src/SharpCode/EnumMemberBuilder.cs
@@ -1,0 +1,57 @@
+using Optional;
+
+namespace SharpCode
+{
+    /// <summary>
+    /// Provides functionality for building enum members. <see cref="EnumMemberBuilder"/> instances are <b>not</b>
+    /// immutable.
+    /// </summary>
+    public class EnumMemberBuilder
+    {
+        private readonly EnumerationMember _enumMember = new EnumerationMember();
+
+        internal EnumMemberBuilder() { }
+
+        internal EnumMemberBuilder(string name, Option<int> value)
+        {
+            _enumMember.Name = name;
+            _enumMember.Value = value;
+        }
+
+        /// <summary>
+        /// Sets the name of the enum member.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the member. Used as-is.
+        /// </param>
+        public EnumMemberBuilder WithName(string name)
+        {
+            _enumMember.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies whether the enum member has an explicit value, and the value itself.
+        /// </summary>
+        /// <param name="value">
+        /// Use <c>null</c> to specify that the enum member should not have an explicit value. Otherwise provide the
+        /// value of the enum member.
+        /// </param>
+        public EnumMemberBuilder WithValue(int? value)
+        {
+            _enumMember.Value = value.ToOption();
+            return this;
+        }
+
+        internal EnumerationMember Build()
+        {
+            if (string.IsNullOrWhiteSpace(_enumMember.Name))
+            {
+                throw new MissingBuilderSettingException(
+                    "Providing the name of the enum member is required when building an enum.");
+            }
+
+            return _enumMember;
+        }
+    }
+}

--- a/src/SharpCode/NamespaceBuilder.cs
+++ b/src/SharpCode/NamespaceBuilder.cs
@@ -20,6 +20,7 @@ namespace SharpCode
         private readonly Namespace _namespace = new Namespace();
         private readonly List<ClassBuilder> _classes = new List<ClassBuilder>();
         private readonly List<InterfaceBuilder> _interfaces = new List<InterfaceBuilder>();
+        private readonly List<EnumBuilder> _enums = new List<EnumBuilder>();
 
         internal NamespaceBuilder() { }
 
@@ -105,6 +106,33 @@ namespace SharpCode
         }
 
         /// <summary>
+        /// Adds an enum definition to the namespace being built.
+        /// </summary>
+        public NamespaceBuilder WithEnum(EnumBuilder builder)
+        {
+            _enums.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of enum definitions to the namespace being built.
+        /// </summary>
+        public NamespaceBuilder WithEnums(params EnumBuilder[] builders)
+        {
+            _enums.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of enum definitions to the namespace being built.
+        /// </summary>
+        public NamespaceBuilder WithEnums(IEnumerable<EnumBuilder> builders)
+        {
+            _enums.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
         /// Returns the source code of the built namespace.
         /// </summary>
         /// <param name="formatted">
@@ -143,6 +171,13 @@ namespace SharpCode
                 .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
                 .MatchSome(item => throw new SyntaxException(
                     "An interface defined under a namespace cannot have the access modifier " +
+                    $"'{item.AccessModifier.ToSourceCode()}'."));
+
+            _namespace.Enums.AddRange(_enums.Select(builder => builder.Build()));
+            _namespace.Enums
+                .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
+                .MatchSome(item => throw new SyntaxException(
+                    "An enum defined under a namespace cannot have the access modifier " +
                     $"'{item.AccessModifier.ToSourceCode()}'."));
 
             return _namespace;

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -72,11 +72,28 @@ namespace SharpCode
         public List<Property> Properties { get; } = new List<Property>();
     }
 
+    internal class EnumerationMember
+    {
+        public string? Name { get; set; }
+        public Option<int> Value { get; set; } = Option.None<int>();
+
+    }
+
+    internal class Enumeration
+    {
+        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public string? Name { get; set; }
+        public bool IsFlag { get; set; }
+        public List<EnumerationMember> Members { get; } = new List<EnumerationMember>();
+        
+    }
+
     internal class Namespace
     {
         public string? Name { get; set; }
         public List<string> Usings { get; } = new List<string>();
         public List<Class> Classes { get; } = new List<Class>();
         public List<Interface> Interfaces { get; } = new List<Interface>();
+        public List<Enumeration> Enums { get; } = new List<Enumeration>();
     }
 }


### PR DESCRIPTION
## Summary

- `SharpCode` can now generate source code for `enum`
- support for enum members with implicit and explicit values
- support for `[Flags]` enums
- integrated enums into namespace generation
- updated the changelog

## Enums are now supported

```csharp
Code.CreateEnum(name: "Rating")
  .WithMembers(
    Code.CreateEnumMember("Nah"),
    Code.CreateEnumMember("Okay"),
    Code.CreateEnumMember("Good"),
    Code.CreateEnumMember("Excelent"))
  .MakeFlagsEnum()
  .ToSourceCode();

// yields
[System.Flags]
public enum Rating
{
    Nah = 0,
    Okay = 1,
    Good = 2,
    Excellent = 4,
}
```

## Flags support

`SharpCode` provides internal support for `[System.Flags]` enums. `.MakeFlagsEnum([true])` marks the enum being built as an enum that contains a collection of flags. If all members are created without explicit values, then `SharpCode` will auto-generate appropriate values, eg. the first member will have a value of `0`, then `1`, `2`, `4`, `8`, etc.

However, if any of the members has an explicit value then `SharpCode` will not attempt to generate flags-compliant values.

## Enums validation

- Creating enums with a `null`, empty or whitespace name throws a `MissingBuilderSettingException`
- Creating enums with duplicate members throws a `SyntaxException`