### PR TITLE
Add more analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,7 @@ dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:error
 dotnet_style_prefer_conditional_expression_over_assignment = true:warning
-dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = false
 dotnet_style_prefer_compound_assignment = true:suggestion
 
 # Null-checking preferences

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         dotnet test
         --verbosity diag
         /p:CollectCoverage=true
+        /p:Exclude="[*]SharpCode.*Exception"
         /p:CoverletOutput=../../coverage/
         /p:CoverletOutputFormat=cobertura
       working-directory: ./src/SharpCode.Test

--- a/SharpCode.ruleset
+++ b/SharpCode.ruleset
@@ -1,0 +1,18 @@
+<RuleSet Name="Analyzer rules for SharpCode" Description="These rules configure the FxCop and StyleCop analyzers." ToolsVersion="10.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
+    <Rule Id="SA1200" Action="None" /> <!-- Using directives must be placed inside the namespace -->
+    <Rule Id="SA1305" Action="Warning" /> <!-- Field names must not use hungarian notation -->
+    <Rule Id="SA1309" Action="None" /> <!-- Field names must not begin with underscore -->
+    <Rule Id="SA1402" Action="None" /> <!-- File may only contain a single type -->
+    <Rule Id="SA1600" Action="None" /> <!-- All elements must be documented -->
+    <Rule Id="SA1602" Action="None" /> <!-- Enumeration items must be documented -->
+    <Rule Id="SA1604" Action="Warning" /> <!-- Elements must have a <summary> documentation -->
+    <Rule Id="SA1609" Action="None" /> <!-- Properties must have <value> documentation -->
+    <Rule Id="SA1611" Action="None" /> <!-- Method parameters must be documented -->
+    <Rule Id="SA1118" Action="None" /> <!-- The parameter spans multiple lines -->
+    <Rule Id="SA1615" Action="None" /> <!-- Return values should be documented -->
+    <Rule Id="SA1633" Action="None" /> <!-- Files must have XML header documentation -->
+    <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
+  </Rules>
+</RuleSet>

--- a/SharpCode.ruleset
+++ b/SharpCode.ruleset
@@ -15,4 +15,8 @@
     <Rule Id="SA1633" Action="None" /> <!-- Files must have XML header documentation -->
     <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
   </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <Rule Id="S1066" Action="None" /> <!-- Collapsible if statements should be merged -->
+    <Rule Id="S3626" Action="None" /> <!-- Jump statements should not be redundant -->
+  </Rules>
 </RuleSet>

--- a/src/SharpCode.Test/.editorconfig
+++ b/src/SharpCode.Test/.editorconfig
@@ -1,5 +1,8 @@
 [*.cs]
 
+# Disable XML comment analysis, since this project does not generate XML docs
+dotnet_diagnostic.SA0001.severity = none
+
 # Unused value preferences
 # Suppress, otherwise every Assert.Throws<T>() must use the discard variable
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/src/SharpCode.Test/ClassBuilderTests.cs
+++ b/src/SharpCode.Test/ClassBuilderTests.cs
@@ -21,7 +21,7 @@ public class User
             Assert.AreEqual(expectedCode, generatedCode);
         }
 
-        [Test] 
+        [Test]
         public void CreateClass_WithSummary_Works()
         {
             var generatedCode = Code.CreateClass("User")

--- a/src/SharpCode.Test/EnumBuilderTests.cs
+++ b/src/SharpCode.Test/EnumBuilderTests.cs
@@ -31,10 +31,10 @@ internal enum UserStatus
 
             Assert.AreEqual(expectedCode, generatedCode);
         }
-         
+
         [Test]
         public void CreatingEnumWithSummary_Works()
-        { 
+        {
             var generatedCode = Code.CreateEnum()
                 .WithAccessModifier(AccessModifier.Internal)
                 .WithName("UserStatus")
@@ -62,7 +62,6 @@ internal enum UserStatus
 
             Assert.AreEqual(expectedCode, generatedCode);
         }
-
 
         [Test]
         public void CreatingFlagsEnum_Works()

--- a/src/SharpCode.Test/FieldBuilderTests.cs
+++ b/src/SharpCode.Test/FieldBuilderTests.cs
@@ -9,7 +9,6 @@ namespace SharpCode.Test
         public void CreateField_Works_WithDefaults()
         {
             var generatedCode = Code.CreateField()
-                .WithAccessModifier(AccessModifier.Private)
                 .WithType(typeof(int))
                 .WithName("_username")
                 .MakeReadonly()

--- a/src/SharpCode.Test/NamespaceBuilderTests.cs
+++ b/src/SharpCode.Test/NamespaceBuilderTests.cs
@@ -241,7 +241,7 @@ namespace GeneratedCode
                 "Generating the source code for a namespace with an empty name should throw an exception.");
             Assert.Throws<MissingBuilderSettingException>(
                 () => Code.CreateNamespace().WithName(string.Empty).ToSourceCode(),
-                    "Generating the source code for a namespace with an empty name should throw an exception.");
+                "Generating the source code for a namespace with an empty name should throw an exception.");
 
             Assert.Throws<MissingBuilderSettingException>(
                 () => Code.CreateNamespace(name: "  ").ToSourceCode(),

--- a/src/SharpCode.Test/SharpCode.Test.csproj
+++ b/src/SharpCode.Test/SharpCode.Test.csproj
@@ -5,6 +5,7 @@
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,10 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.13.1.21947">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/SharpCode.Test/SharpCode.Test.csproj
+++ b/src/SharpCode.Test/SharpCode.Test.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
-
     <IsPackable>false</IsPackable>
+    <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +15,10 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpCode/ClassBuilder.cs
+++ b/src/SharpCode/ClassBuilder.cs
@@ -15,7 +15,9 @@ namespace SharpCode
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
         private readonly List<ConstructorBuilder> _constructors = new List<ConstructorBuilder>();
 
-        internal ClassBuilder() { }
+        internal ClassBuilder()
+        {
+        }
 
         internal ClassBuilder(AccessModifier accessModifier, string name)
         {

--- a/src/SharpCode/ClassBuilder.cs
+++ b/src/SharpCode/ClassBuilder.cs
@@ -62,10 +62,10 @@ namespace SharpCode
         }
 
         /// <summary>
-        /// Adds XML summary documentation to the class
+        /// Adds XML summary documentation to the class.
         /// </summary>
         /// <param name="summaryDocs">
-        /// The content of the summary documentation
+        /// The content of the summary documentation.
         /// </param>
         public ClassBuilder WithSummary(string summaryDocs)
         {

--- a/src/SharpCode/ConstructorBuilder.cs
+++ b/src/SharpCode/ConstructorBuilder.cs
@@ -38,14 +38,13 @@ namespace SharpCode
         /// </param>
         /// <param name="receivingMember">
         /// A member of the class to which this parameter will be assigned. Providing this parameter will result in
-        /// the following line being added to the constructor body - <c>{receivingMember} = {name};</c>
+        /// the following line being added to the constructor body - <c>{receivingMember} = {name};</c>.
         /// </param>
         /// <example>
         /// This example shows the generated code for a constructor with a parameter.
         ///
         /// <code>
         /// // ConstructorBuilder.WithParameter("string", "username");
-        /// 
         /// public User(string username)
         /// {
         /// }
@@ -56,7 +55,6 @@ namespace SharpCode
         ///
         /// <code>
         /// // ConstructorBuilder.WithParameter("string", "username", "_username");
-        /// 
         /// public User(string username)
         /// {
         ///     _username = username;
@@ -85,14 +83,13 @@ namespace SharpCode
         /// </param>
         /// <param name="receivingMember">
         /// A member of the class to which this parameter will be assigned. Providing this parameter will result in
-        /// the following line being added to the constructor body - <c>{receivingMember} = {name};</c>
+        /// the following line being added to the constructor body - <c>{receivingMember} = {name};</c>.
         /// </param>
         /// <example>
         /// This example shows the generated code for a constructor with a parameter.
         ///
         /// <code>
         /// // ConstructorBuilder.WithParameter(typeof(string), "username");
-        /// 
         /// public User(String username)
         /// {
         /// }
@@ -103,7 +100,6 @@ namespace SharpCode
         ///
         /// <code>
         /// // ConstructorBuilder.WithParameter(typeof(string), "username", "_username");
-        /// 
         /// public User(String username)
         /// {
         ///     _username = username;
@@ -132,7 +128,6 @@ namespace SharpCode
         ///
         /// <code>
         /// // ConstructorBuilder.WithBaseCall();
-        /// 
         /// public User(): base()
         /// {
         /// }
@@ -143,7 +138,6 @@ namespace SharpCode
         ///
         /// <code>
         /// // ConstructorBuilder.WithParameter("string", "username").WithBaseCall("username");
-        /// 
         /// public User(string username): base(username)
         /// {
         /// }

--- a/src/SharpCode/EnumBuilder.cs
+++ b/src/SharpCode/EnumBuilder.cs
@@ -15,7 +15,9 @@ namespace SharpCode
         private readonly Enumeration _enumeration = new Enumeration();
         private readonly List<EnumMemberBuilder> _members = new List<EnumMemberBuilder>();
 
-        internal EnumBuilder() { }
+        internal EnumBuilder()
+        {
+        }
 
         internal EnumBuilder(string name, AccessModifier accessModifier)
         {
@@ -94,7 +96,6 @@ namespace SharpCode
         /// <summary>
         /// Returns the source code of the built enum.
         /// </summary>
-        /// <returns></returns>
         public override string ToString() =>
             ToSourceCode();
 
@@ -114,7 +115,6 @@ namespace SharpCode
                 .FirstOrNone()
                 .MatchSome(duplicateMemberName => throw new SyntaxException(
                     $"The enum '{_enumeration.Name}' already contains a definition for '{duplicateMemberName}'."));
-
 
             if (_enumeration.IsFlag && _enumeration.Members.All(x => !x.Value.HasValue))
             {

--- a/src/SharpCode/EnumMemberBuilder.cs
+++ b/src/SharpCode/EnumMemberBuilder.cs
@@ -46,10 +46,10 @@ namespace SharpCode
         }
 
         /// <summary>
-        /// Adds XML summary documentation to the enum member
+        /// Adds XML summary documentation to the enum member.
         /// </summary>
         /// <param name="summaryDocs">
-        /// The content of the summary documentation
+        /// The content of the summary documentation.
         /// </param>
         public EnumMemberBuilder WithSummary(string summaryDocs)
         {

--- a/src/SharpCode/EnumMemberBuilder.cs
+++ b/src/SharpCode/EnumMemberBuilder.cs
@@ -10,7 +10,9 @@ namespace SharpCode
     {
         private readonly EnumerationMember _enumMember = new EnumerationMember();
 
-        internal EnumMemberBuilder() { }
+        internal EnumMemberBuilder()
+        {
+        }
 
         internal EnumMemberBuilder(string name, Option<int> value)
         {

--- a/src/SharpCode/Extensions.cs
+++ b/src/SharpCode/Extensions.cs
@@ -60,8 +60,7 @@ namespace SharpCode
                 .Replace("{parameters}", constructor.Parameters.Select(param => param.ToSourceCode()).Join(", "))
                 .Replace("{base-call}", constructor.BaseCallParameters.Match(
                     some: (parameters) => $": base({parameters.Join(", ")})",
-                    none: () => string.Empty
-                ))
+                    none: () => string.Empty))
                 .Replace(
                     "{assignments}",
                     constructor.Parameters

--- a/src/SharpCode/Extensions.cs
+++ b/src/SharpCode/Extensions.cs
@@ -93,14 +93,26 @@ namespace SharpCode
                     ? "}"
                     : string.Empty)
                 .Replace("{getter}", property.Getter.Match(
-                    some: (getter) => string.IsNullOrWhiteSpace(getter)
-                        ? "get;"
-                        : getter!.StartsWith("{") ? $"get{getter}" : $"get => {getter};",
+                    some: (getter) =>
+                    {
+                        if (string.IsNullOrWhiteSpace(getter))
+                        {
+                            return "get;";
+                        }
+
+                        return getter!.StartsWith("{") ? $"get{getter}" : $"get => {getter};";
+                    },
                     none: () => string.Empty))
                 .Replace("{setter}", property.Setter.Match(
-                    some: (setter) => string.IsNullOrWhiteSpace(setter)
-                        ? "set;"
-                        : setter!.StartsWith("{") ? $"set{setter}" : $"set => {setter};",
+                    some: (setter) =>
+                    {
+                        if (string.IsNullOrWhiteSpace(setter))
+                        {
+                            return "set;";
+                        }
+
+                        return setter!.StartsWith("{") ? $"set{setter}" : $"set => {setter};";
+                    },
                     none: () => string.Empty))
                 .Replace("{default-value}", property.DefaultValue.Match(
                     some: (def) =>

--- a/src/SharpCode/Extensions.cs
+++ b/src/SharpCode/Extensions.cs
@@ -48,27 +48,6 @@ namespace SharpCode
                 .Replace("{name}", parameter.Name);
         }
 
-        private static string SummaryBlock(Option<string> summaryDocs)
-        {
-            var docs = summaryDocs.ValueOr(string.Empty);
-
-            if (string.IsNullOrWhiteSpace(docs))
-            {
-                return string.Empty;
-            }
-             
-            var blockParts = new[]
-            {
-                 "/// <summary>",
-                 "/// " + docs.Replace("\r\n", "\n/// ").Replace("\n", "\n/// ") ,
-                 "/// </summary>",
-                 string.Empty
-            };
-
-            return string.Join("\n", blockParts);
-        }
-
-
         public static string ToSourceCode(this Constructor constructor, bool formatted)
         {
             const string Template = @"
@@ -146,7 +125,7 @@ namespace SharpCode
                         return defValue;
                     },
                     none: () => string.Empty))
-                .Replace("{documentation}", SummaryBlock(property.Summary)); 
+                .Replace("{documentation}", SummaryBlock(property.Summary));
 
             return formatted ? raw.FormatSourceCode() : raw;
         }
@@ -250,6 +229,26 @@ namespace {name}
                 .Replace("{classes}", data.Classes.Select(item => item.ToSourceCode(false)).Join("\n"));
 
             return formatted ? raw.FormatSourceCode() : raw;
+        }
+
+        private static string SummaryBlock(Option<string> summaryDocs)
+        {
+            var docs = summaryDocs.ValueOr(string.Empty);
+
+            if (string.IsNullOrWhiteSpace(docs))
+            {
+                return string.Empty;
+            }
+
+            var blockParts = new[]
+            {
+                 "/// <summary>",
+                 "/// " + docs.Replace("\r\n", "\n/// ").Replace("\n", "\n/// "),
+                 "/// </summary>",
+                 string.Empty,
+            };
+
+            return string.Join("\n", blockParts);
         }
     }
 }

--- a/src/SharpCode/FieldBuilder.cs
+++ b/src/SharpCode/FieldBuilder.cs
@@ -9,7 +9,9 @@ namespace SharpCode
     {
         private readonly Field _field = new Field();
 
-        internal FieldBuilder() { }
+        internal FieldBuilder()
+        {
+        }
 
         internal FieldBuilder(AccessModifier accessModifier, string type, string name)
         {

--- a/src/SharpCode/InterfaceBuilder.cs
+++ b/src/SharpCode/InterfaceBuilder.cs
@@ -12,7 +12,9 @@ namespace SharpCode
         private readonly Interface _interface = new Interface();
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
 
-        internal InterfaceBuilder() { }
+        internal InterfaceBuilder()
+        {
+        }
 
         internal InterfaceBuilder(string name, AccessModifier accessModifier)
         {

--- a/src/SharpCode/MissingBuilderSettingException.cs
+++ b/src/SharpCode/MissingBuilderSettingException.cs
@@ -11,27 +11,32 @@ namespace SharpCode
         /// <summary>
         /// Initializes a new instance of the <see cref="MissingBuilderSettingException"/> class.
         /// </summary>
-        public MissingBuilderSettingException() { }
+        public MissingBuilderSettingException()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MissingBuilderSettingException"/> class.
         /// </summary>
         public MissingBuilderSettingException(string message)
             : base(message)
-        { }
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MissingBuilderSettingException"/> class.
         /// </summary>
         public MissingBuilderSettingException(string message, Exception innerException)
             : base(message, innerException)
-        { }
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MissingBuilderSettingException"/> class.
         /// </summary>
         protected MissingBuilderSettingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
-        { }
+        {
+        }
     }
 }

--- a/src/SharpCode/MissingBuilderSettingException.cs
+++ b/src/SharpCode/MissingBuilderSettingException.cs
@@ -6,6 +6,7 @@ namespace SharpCode
     /// <summary>
     /// The exception that is thrown when attempting to build source code, but a required setting is missing.
     /// </summary>
+    [Serializable]
     public class MissingBuilderSettingException : Exception
     {
         /// <summary>

--- a/src/SharpCode/NamespaceBuilder.cs
+++ b/src/SharpCode/NamespaceBuilder.cs
@@ -14,7 +14,7 @@ namespace SharpCode
         {
             AccessModifier.None,
             AccessModifier.Internal,
-            AccessModifier.Public
+            AccessModifier.Public,
         };
 
         private readonly Namespace _namespace = new Namespace();
@@ -22,7 +22,9 @@ namespace SharpCode
         private readonly List<InterfaceBuilder> _interfaces = new List<InterfaceBuilder>();
         private readonly List<EnumBuilder> _enums = new List<EnumBuilder>();
 
-        internal NamespaceBuilder() { }
+        internal NamespaceBuilder()
+        {
+        }
 
         internal NamespaceBuilder(string name)
         {

--- a/src/SharpCode/PropertyBuilder.cs
+++ b/src/SharpCode/PropertyBuilder.cs
@@ -11,7 +11,9 @@ namespace SharpCode
     {
         private readonly Property _property = new Property();
 
-        internal PropertyBuilder() { }
+        internal PropertyBuilder()
+        {
+        }
 
         internal PropertyBuilder(AccessModifier accessModifier, string type, string name)
         {
@@ -65,14 +67,12 @@ namespace SharpCode
         /// Sets the getter logic of the property being built.
         /// </summary>
         /// <param name="expression">
-        /// The expression or block body of the getter. If not specified the default getter will be used - <c>get;</c>
+        /// The expression or block body of the getter. If not specified the default getter will be used - <c>get;</c>.
         /// </param>
         /// <example>
         /// This example shows the generated code for a property with a default getter.
-        /// 
         /// <code>
         /// // PropertyBuilder.WithName("Identifier").WithGetter()
-        /// 
         /// public int Identifier
         /// {
         ///     get;
@@ -81,10 +81,8 @@ namespace SharpCode
         /// </example>
         /// <example>
         /// This example shows the generated code for a property with a getter that is an expression.
-        /// 
         /// <code>
         /// // PropertyBuilder.WithName("Identifier").WithGetter("_id")
-        /// 
         /// public int Identifier
         /// {
         ///     get => _id;
@@ -93,10 +91,8 @@ namespace SharpCode
         /// </example>
         /// <example>
         /// This example shows the generated code for a property with a getter that has a block body.
-        /// 
         /// <code>
         /// // PropertyBuilder.WithName("IsCreated").WithGetter("{ if (_id == -1) { return false; } else { return true; } }")
-        /// 
         /// public int Identifier
         /// {
         ///     get
@@ -137,10 +133,8 @@ namespace SharpCode
         /// </param>
         /// <example>
         /// This example shows the generated code for a property with a default setter.
-        /// 
         /// <code>
         /// // PropertyBuilder.WithName("Identifier").WithSetter()
-        /// 
         /// public int Identifier
         /// {
         ///     set;
@@ -149,10 +143,8 @@ namespace SharpCode
         /// </example>
         /// <example>
         /// This example shows the generated code for a property with a setter that is an expression.
-        /// 
         /// <code>
         /// // PropertyBuilder.WithName("Identifier").WithSetter("_id = value")
-        /// 
         /// public int Identifier
         /// {
         ///     set => _id = value;
@@ -161,11 +153,9 @@ namespace SharpCode
         /// </example>
         /// <example>
         /// This example shows the generated code for a property with a setter that has a block body.
-        /// 
         /// <code>
         /// // PropertyBuilder.WithName("Value")
         /// //    .WithSetter("{ if (value &lt;= 0) { throw new Exception(); } _value = value; }")
-        /// 
         /// public int Identifier
         /// {
         ///     set
@@ -203,7 +193,7 @@ namespace SharpCode
         /// <param name="defaultValue">
         /// The default value of the property. The value is used as-is, therefore you should wrap any string values in
         /// escaped quotes. For example,
-        /// <c>WithDefaultValue(defaultValue: "\"this will be generated as a string\"")</c>
+        /// <c>WithDefaultValue(defaultValue: "\"this will be generated as a string\"")</c>.
         /// </param>
         public PropertyBuilder WithDefaultValue(string defaultValue)
         {

--- a/src/SharpCode/PropertyBuilder.cs
+++ b/src/SharpCode/PropertyBuilder.cs
@@ -214,10 +214,10 @@ namespace SharpCode
         }
 
         /// <summary>
-        /// Adds XML summary documentation to the property
+        /// Adds XML summary documentation to the property.
         /// </summary>
         /// <param name="summaryDocs">
-        /// The content of the summary documentation
+        /// The content of the summary documentation.
         /// </param>
         public PropertyBuilder WithSummary(string summaryDocs)
         {

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -6,6 +6,7 @@
     <Nullable>Enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -24,6 +25,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.13.1.21947">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -5,6 +5,7 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -23,6 +24,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -8,6 +8,7 @@ namespace SharpCode
     /// </summary>
     public enum AccessModifier
     {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         None,
         Private,
         Internal,
@@ -15,6 +16,7 @@ namespace SharpCode
         Public,
         PrivateInternal,
         ProtectedInternal,
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 
     internal class Field

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -20,80 +20,111 @@ namespace SharpCode
     internal class Field
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Private;
+
         public bool IsReadonly { get; set; }
+
         public string? Type { get; set; }
+
         public string? Name { get; set; }
     }
 
     internal class Property
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
         public bool IsStatic { get; set; } = false;
+
         public string? Type { get; set; }
+
         public string? Name { get; set; }
+
         public Option<string> DefaultValue { get; set; } = Option.None<string>();
+
         public Option<string?> Getter { get; set; } = Option.Some<string?>(null);
+
         public Option<string?> Setter { get; set; } = Option.Some<string?>(null);
     }
 
     internal class Parameter
     {
         public string? Type { get; set; }
+
         public string? Name { get; set; }
+
         public string? ReceivingMember { get; set; }
     }
 
     internal class Constructor
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
         public bool IsStatic { get; set; } = false;
+
         public string? ClassName { get; set; }
+
         public List<Parameter> Parameters { get; set; } = new List<Parameter>();
+
         public Option<IEnumerable<string>> BaseCallParameters { get; set; } = Option.None<IEnumerable<string>>();
     }
 
     internal class Class
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
         public bool IsStatic { get; set; } = false;
+
         public string? Name { get; set; }
+
         public Option<string> InheritedClass { get; set; } = Option.None<string>();
+
         public List<string> ImplementedInterfaces { get; } = new List<string>();
+
         public List<Field> Fields { get; } = new List<Field>();
+
         public List<Property> Properties { get; } = new List<Property>();
+
         public List<Constructor> Constructors { get; } = new List<Constructor>();
     }
 
     internal class Interface
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
         public string? Name { get; set; }
+
         public List<string> ImplementedInterfaces { get; } = new List<string>();
+
         public List<Property> Properties { get; } = new List<Property>();
     }
 
     internal class EnumerationMember
     {
         public string? Name { get; set; }
-        public Option<int> Value { get; set; } = Option.None<int>();
 
+        public Option<int> Value { get; set; } = Option.None<int>();
     }
 
     internal class Enumeration
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
         public string? Name { get; set; }
+
         public bool IsFlag { get; set; }
+
         public List<EnumerationMember> Members { get; } = new List<EnumerationMember>();
-        
     }
 
     internal class Namespace
     {
         public string? Name { get; set; }
+
         public List<string> Usings { get; } = new List<string>();
+
         public List<Class> Classes { get; } = new List<Class>();
+
         public List<Interface> Interfaces { get; } = new List<Interface>();
+
         public List<Enumeration> Enums { get; } = new List<Enumeration>();
     }
 }

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -40,9 +40,10 @@ namespace SharpCode
 
         public string? Name { get; set; }
 
-        public Option<string> DefaultValue { get; set; } = Option.None<string>();
         public Option<string> Summary { get; set; } = Option.None<string>();
-        
+
+        public Option<string> DefaultValue { get; set; } = Option.None<string>();
+
         public Option<string?> Getter { get; set; } = Option.Some<string?>(null);
 
         public Option<string?> Setter { get; set; } = Option.Some<string?>(null);
@@ -78,10 +79,12 @@ namespace SharpCode
 
         public string? Name { get; set; }
 
+        public Option<string> Summary { get; set; } = Option.None<string>();
+
         public Option<string> InheritedClass { get; set; } = Option.None<string>();
 
         public List<string> ImplementedInterfaces { get; } = new List<string>();
-        public Option<string> Summary { get; set; } = Option.None<string>();
+
         public List<Field> Fields { get; } = new List<Field>();
 
         public List<Property> Properties { get; } = new List<Property>();
@@ -103,7 +106,9 @@ namespace SharpCode
     internal class EnumerationMember
     {
         public string? Name { get; set; }
+
         public Option<int> Value { get; set; } = Option.None<int>();
+
         public Option<string> Summary { get; set; } = Option.None<string>();
     }
 

--- a/src/SharpCode/SyntaxException.cs
+++ b/src/SharpCode/SyntaxException.cs
@@ -11,27 +11,32 @@ namespace SharpCode
         /// <summary>
         /// Initializes a new instance of the <see cref="SyntaxException"/> class.
         /// </summary>
-        public SyntaxException() { }
+        public SyntaxException()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SyntaxException"/> class.
         /// </summary>
         public SyntaxException(string message)
             : base(message)
-        { }
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SyntaxException"/> class.
         /// </summary>
         public SyntaxException(string message, Exception innerException)
             : base(message, innerException)
-        { }
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SyntaxException"/> class.
         /// </summary>
         protected SyntaxException(SerializationInfo info, StreamingContext context)
             : base(info, context)
-        { }
+        {
+        }
     }
 }

--- a/src/SharpCode/SyntaxException.cs
+++ b/src/SharpCode/SyntaxException.cs
@@ -6,6 +6,7 @@ namespace SharpCode
     /// <summary>
     /// The exception that is thrown when building with the provided configuration will result in invalid source code.
     /// </summary>
+    [Serializable]
     public class SyntaxException : Exception
     {
         /// <summary>

--- a/src/SharpCode/Utils.cs
+++ b/src/SharpCode/Utils.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace SharpCode
 {
-    internal class Utils
+    internal static class Utils
     {
         public static string FormatSourceCode(string sourceCode) =>
             SyntaxNodeExtensions


### PR DESCRIPTION
This pull request adds more static code analyzers to the project, tweaks the rules and fixes the code to adhere. New analyzers:

- [StyleCop.Analyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers)
- [SonarAnalyzer.CSharp](https://github.com/SonarSource/sonar-dotnet)

Additional changes:

- treat build warnings as errors
- excluded `*Exception` classes from code coverage