### PR TITLE
Add support for structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code coverage, via CodeCov
 - Support for generating XML summary documentation ([Zaid Ajaj](https://github.com/Zaid-Ajaj))
 - [StyleCop.Analyzer](https://github.com/DotNetAnalyzers/StyleCopAnalyzers) and [SonarAnalyzer.CSharp](https://github.com/SonarSource/sonar-dotnet)
+- Support for structs generation
 
 ## [0.1.0] - 2020-09-26
 

--- a/src/SharpCode.Test/NamespaceBuilderTests.cs
+++ b/src/SharpCode.Test/NamespaceBuilderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -279,6 +280,31 @@ namespace GeneratedCode
                     .ToSourceCode(),
                 "Generating the source code for a protected internal class inside a namespace should throw an exception.");
 
+            // -- Structs
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithStruct(Code.CreateStruct("Test", AccessModifier.Private))
+                    .ToSourceCode(),
+                "Generating the source code for a private struct inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithStruct(Code.CreateStruct("Test", AccessModifier.PrivateInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a private internal struct inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithStruct(Code.CreateStruct("Test", AccessModifier.Protected))
+                    .ToSourceCode(),
+                "Generating the source code for a protected struct inside a namespace should throw an exception.");
+
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateNamespace("Test")
+                    .WithStruct(Code.CreateStruct("Test", AccessModifier.ProtectedInternal))
+                    .ToSourceCode(),
+                "Generating the source code for a protected internal struct inside a namespace should throw an exception.");
+
             // -- Interfaces
             Assert.Throws<SyntaxException>(
                 () => Code.CreateNamespace("Test")
@@ -366,6 +392,146 @@ namespace GeneratedGoodies
             ".Trim().WithUnixEOL();
 
             Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingNamespace_WithStruct_Works()
+        {
+            var generatedCode = Code.CreateNamespace()
+                .WithName("Geometry")
+                .WithStruct(Code.CreateStruct()
+                    .WithAccessModifier(AccessModifier.Public)
+                    .WithName("Cube")
+                    .WithSummary("Represents a geometrical cube.")
+                    .WithProperty(Code.CreateProperty("int", "Side").WithSummary("Gets or sets the length of the cube side.")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+namespace Geometry
+{
+    /// <summary>
+    /// Represents a geometrical cube.
+    /// </summary>
+    public struct Cube
+    {
+        /// <summary>
+        /// Gets or sets the length of the cube side.
+        /// </summary>
+        public int Side
+        {
+            get;
+            set;
+        }
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void NamespaceBuilder_WithStructs_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateNamespace("Test")
+                .WithStructs(new List<StructBuilder>
+                {
+                    Code.CreateStruct("Position"),
+                    Code.CreateStruct("Location"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateNamespace("Test")
+                .WithStructs(
+                    Code.CreateStruct("Position"),
+                    Code.CreateStruct("Location"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void NamespaceBuilder_WithClasses_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateNamespace("Test")
+                .WithClasses(new List<ClassBuilder>
+                {
+                    Code.CreateClass()
+                        .WithAccessModifier(AccessModifier.Internal)
+                        .WithName("Tester"),
+                    Code.CreateClass()
+                        .WithAccessModifier(AccessModifier.Public)
+                        .WithName("PublicTester"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateNamespace("Test")
+                .WithClasses(
+                    Code.CreateClass()
+                        .WithAccessModifier(AccessModifier.Internal)
+                        .WithName("Tester"),
+                    Code.CreateClass()
+                        .WithAccessModifier(AccessModifier.Public)
+                        .WithName("PublicTester"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void NamespaceBuilder_WithInterfaces_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateNamespace("Test")
+                .WithInterfaces(new List<InterfaceBuilder>
+                {
+                    Code.CreateInterface()
+                        .WithAccessModifier(AccessModifier.Internal)
+                        .WithName("ITester"),
+                    Code.CreateInterface()
+                        .WithAccessModifier(AccessModifier.Public)
+                        .WithName("IPublicTester"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateNamespace("Test")
+                .WithInterfaces(
+                    Code.CreateInterface()
+                        .WithAccessModifier(AccessModifier.Internal)
+                        .WithName("ITester"),
+                    Code.CreateInterface()
+                        .WithAccessModifier(AccessModifier.Public)
+                        .WithName("IPublicTester"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void NamespaceBuilder_WithEnums_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateNamespace("Test")
+                .WithEnums(new List<EnumBuilder>
+                {
+                    Code.CreateEnum()
+                        .WithAccessModifier(AccessModifier.Internal)
+                        .WithName("UserStatus"),
+                    Code.CreateEnum()
+                        .WithAccessModifier(AccessModifier.Public)
+                        .WithName("TestStatus"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateNamespace("Test")
+                .WithEnums(
+                    Code.CreateEnum()
+                        .WithAccessModifier(AccessModifier.Internal)
+                        .WithName("UserStatus"),
+                    Code.CreateEnum()
+                        .WithAccessModifier(AccessModifier.Public)
+                        .WithName("TestStatus"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
         }
     }
 }

--- a/src/SharpCode.Test/StructBuilderTests.cs
+++ b/src/SharpCode.Test/StructBuilderTests.cs
@@ -1,0 +1,240 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace SharpCode.Test
+{
+    [TestFixture]
+    public class StructBuilderTests
+    {
+        [Test]
+        public void CreatingStruct_WithoutRequiredSettings_Throws()
+        {
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct().ToSourceCode(),
+                "Generating the source code for a struct without a name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct().WithName(null).ToSourceCode(),
+                "Generating the source code for a struct with null as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct().WithName(string.Empty).ToSourceCode(),
+                "Generating the source code for a struct with an empty string as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct().WithName("   ").ToSourceCode(),
+                "Generating the source code for a struct with whitespace as name should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingStruct_WithParameterlessConstructor_Throws()
+        {
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateStruct(name: "Test").WithConstructor(Code.CreateConstructor()).ToSourceCode(),
+                "Generating the source code for a struct with a parameterless constructor should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingStruct_WithImplementedInterface_WithInvalidName_Throws()
+        {
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct(name: "Test").WithImplementedInterface(null).ToSourceCode(),
+                "Generating the source code for a struct with null as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct(name: "Test").WithImplementedInterface(string.Empty).ToSourceCode(),
+                "Generating the source code for a struct with an empty string as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateStruct(name: "Test").WithImplementedInterface("   ").ToSourceCode(),
+                "Generating the source code for a struct with whitespace as name should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingStruct_WithProperties_WithDefaultValue_Throws()
+        {
+            Assert.Throws<SyntaxException>(
+                () => Code.CreateStruct(name: "Test")
+                    .WithProperty(Code.CreateProperty("string", "Name").WithDefaultValue("\"fail\""))
+                    .ToSourceCode(),
+                "Generating the source code for a struct with a property which has a default value should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingStruct_Works()
+        {
+            var generatedCode = Code.CreateStruct()
+                .WithSummary("Represents an X/Y position.")
+                .WithAccessModifier(AccessModifier.ProtectedInternal)
+                .WithName("Position")
+                .WithImplementedInterface("IComparable")
+                .WithFields(
+                    Code.CreateField("int", "_x"),
+                    Code.CreateField("int", "_y"))
+                .WithConstructor(Code.CreateConstructor()
+                    .WithParameter("int", "x", "_x")
+                    .WithParameter("int", "y", "_y"))
+                .WithProperties(
+                    Code.CreateProperty("int", "X").WithGetter("_x").WithSetter("_x = value"),
+                    Code.CreateProperty("int", "Y").WithGetter("_y").WithSetter("_y = value"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+/// <summary>
+/// Represents an X/Y position.
+/// </summary>
+protected internal struct Position : IComparable
+{
+    private int _x;
+    private int _y;
+    public Position(int x, int y)
+    {
+        _x = x;
+        _y = y;
+    }
+
+    public int X
+    {
+        get => _x;
+        set => _x = value;
+    }
+
+    public int Y
+    {
+        get => _y;
+        set => _y = value;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingStruct_WithoutConstructor_Works()
+        {
+            var generatedCode = Code.CreateStruct(name: "Position")
+                .WithField(Code.CreateField("int", "_x"))
+                .WithField(Code.CreateField("int", "_y"))
+                .WithProperties(new List<PropertyBuilder>
+                {
+                    Code.CreateProperty("int", "X").WithGetter("_x").WithSetter("_x = value"),
+                    Code.CreateProperty("int", "Y").WithGetter("_y").WithSetter("_y = value"),
+                })
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Position
+{
+    private int _x;
+    private int _y;
+    public int X
+    {
+        get => _x;
+        set => _x = value;
+    }
+
+    public int Y
+    {
+        get => _y;
+        set => _y = value;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void StructBuilder_WithImplementedInterfaces_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.None)
+                .WithName("Test")
+                .WithImplementedInterfaces(new List<string>
+                {
+                    "IHasNoMembers",
+                    "IAmAStruct",
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.None)
+                .WithName("Test")
+                .WithImplementedInterfaces(
+                    "IHasNoMembers",
+                    "IAmAStruct")
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void StructBuilder_WithFields_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.Private)
+                .WithName("Test")
+                .WithFields(new List<FieldBuilder>
+                {
+                    Code.CreateField("int", "_count"),
+                    Code.CreateField("string", "_name"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.Private)
+                .WithName("Test")
+                .WithFields(
+                    Code.CreateField("int", "_count"),
+                    Code.CreateField("string", "_name"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void StructBuilder_WithProperties_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.Private)
+                .WithName("Test")
+                .WithProperties(new List<PropertyBuilder>
+                {
+                    Code.CreateProperty("int", "Count"),
+                    Code.CreateProperty("string", "Name"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.Private)
+                .WithName("Test")
+                .WithProperties(
+                    Code.CreateProperty("int", "Count"),
+                    Code.CreateProperty("string", "Name"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void StructBuilder_ToSourceCode_ToString_Identical()
+        {
+            var toSourceCode = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.Internal)
+                .WithName("Structure")
+                .WithProperty(Code.CreateProperty("double", "Seed"))
+                .ToSourceCode();
+
+            var toString = Code.CreateStruct()
+                .WithAccessModifier(AccessModifier.Internal)
+                .WithName("Structure")
+                .WithProperty(Code.CreateProperty("double", "Seed"))
+                .ToString();
+
+            Assert.AreEqual(toSourceCode, toString);
+        }
+    }
+}

--- a/src/SharpCode/ClassBuilder.cs
+++ b/src/SharpCode/ClassBuilder.cs
@@ -69,7 +69,7 @@ namespace SharpCode
         /// </param>
         public ClassBuilder WithSummary(string summary)
         {
-            _class.Summary = Option.Some(summary);
+            _class.Summary = Option.Some<string?>(summary);
             return this;
         }
 
@@ -174,7 +174,7 @@ namespace SharpCode
             _class.Properties.AddRange(_properties.Select(builder => builder.Build()));
             _class.Constructors.AddRange(
                 _constructors.Select(builder => builder
-                    .WithClassName(_class.Name!)
+                    .WithName(_class.Name!)
                     .MakeStatic(_class.IsStatic)
                     .Build()));
 

--- a/src/SharpCode/Code.cs
+++ b/src/SharpCode/Code.cs
@@ -110,6 +110,26 @@ namespace SharpCode
             new ClassBuilder(accessModifier, name);
 
         /// <summary>
+        /// Creates a new <see cref="StructBuilder"/> instance for building structs.
+        /// </summary>
+        public static StructBuilder CreateStruct() =>
+            new StructBuilder();
+
+        /// <summary>
+        /// Creates a new pre-configured <see cref="StructBuilder"/> instance for building structs. Configures the
+        /// <see cref="StructBuilder"/> instance with the specified <paramref name="name"/> and
+        /// <paramref name="accessModifier"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the struct.
+        /// </param>
+        /// <param name="accessModifier">
+        /// The access modifier of the struct.
+        /// </param>
+        public static StructBuilder CreateStruct(string name, AccessModifier accessModifier = AccessModifier.Public) =>
+            new StructBuilder(name, accessModifier);
+
+        /// <summary>
         /// Creates a new <see cref="FieldBuilder"/> instance for building fields.
         /// </summary>
         public static FieldBuilder CreateField() =>

--- a/src/SharpCode/ConstructorBuilder.cs
+++ b/src/SharpCode/ConstructorBuilder.cs
@@ -157,7 +157,7 @@ namespace SharpCode
         /// </param>
         public ConstructorBuilder WithSummary(string summary)
         {
-            _constructor.Summary = Option.Some(summary);
+            _constructor.Summary = Option.Some<string?>(summary);
             return this;
         }
 
@@ -167,7 +167,7 @@ namespace SharpCode
             return this;
         }
 
-        internal ConstructorBuilder WithClassName(string name)
+        internal ConstructorBuilder WithName(string name)
         {
             _constructor.ClassName = name;
             return this;

--- a/src/SharpCode/EnumBuilder.cs
+++ b/src/SharpCode/EnumBuilder.cs
@@ -92,7 +92,7 @@ namespace SharpCode
         /// </param>
         public EnumBuilder WithSummary(string summary)
         {
-            _enumeration.Summary = Option.Some(summary);
+            _enumeration.Summary = Option.Some<string?>(summary);
             return this;
         }
 

--- a/src/SharpCode/EnumMemberBuilder.cs
+++ b/src/SharpCode/EnumMemberBuilder.cs
@@ -53,7 +53,7 @@ namespace SharpCode
         /// </param>
         public EnumMemberBuilder WithSummary(string summary)
         {
-            _enumMember.Summary = Option.Some(summary);
+            _enumMember.Summary = Option.Some<string?>(summary);
             return this;
         }
 

--- a/src/SharpCode/FieldBuilder.cs
+++ b/src/SharpCode/FieldBuilder.cs
@@ -82,7 +82,7 @@ namespace SharpCode
         /// </param>
         public FieldBuilder WithSummary(string summary)
         {
-            _field.Summary = Option.Some(summary);
+            _field.Summary = Option.Some<string?>(summary);
             return this;
         }
 

--- a/src/SharpCode/InterfaceBuilder.cs
+++ b/src/SharpCode/InterfaceBuilder.cs
@@ -85,7 +85,7 @@ namespace SharpCode
         /// </param>
         public InterfaceBuilder WithSummary(string summary)
         {
-            _interface.Summary = Option.Some(summary);
+            _interface.Summary = Option.Some<string?>(summary);
             return this;
         }
 

--- a/src/SharpCode/NamespaceBuilder.cs
+++ b/src/SharpCode/NamespaceBuilder.cs
@@ -19,6 +19,7 @@ namespace SharpCode
 
         private readonly Namespace _namespace = new Namespace();
         private readonly List<ClassBuilder> _classes = new List<ClassBuilder>();
+        private readonly List<StructBuilder> _structs = new List<StructBuilder>();
         private readonly List<InterfaceBuilder> _interfaces = new List<InterfaceBuilder>();
         private readonly List<EnumBuilder> _enums = new List<EnumBuilder>();
 
@@ -135,23 +136,55 @@ namespace SharpCode
         }
 
         /// <summary>
-        /// Returns the source code of the built namespace.
+        /// Adds a struct to the namespace.
         /// </summary>
-        /// <param name="formatted">
-        /// Indicates whether to format the source code.
+        /// <param name="builder">
+        /// The configuration of the struct.
         /// </param>
-        public string ToSourceCode(bool formatted = true)
+        public NamespaceBuilder WithStruct(StructBuilder builder)
         {
-            return Build().ToSourceCode(formatted);
+            _structs.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of structs to the namespace.
+        /// </summary>
+        /// <param name="builders">
+        /// A collection of structs which will be added to the namespace.
+        /// </param>
+        public NamespaceBuilder WithStructs(params StructBuilder[] builders)
+        {
+            _structs.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of structs to the namespace.
+        /// </summary>
+        /// <param name="builders">
+        /// A collection of structs which will be added to the namespace.
+        /// </param>
+        public NamespaceBuilder WithStructs(IEnumerable<StructBuilder> builders)
+        {
+            _structs.AddRange(builders);
+            return this;
         }
 
         /// <summary>
         /// Returns the source code of the built namespace.
         /// </summary>
-        public override string ToString()
-        {
-            return ToSourceCode();
-        }
+        /// <param name="formatted">
+        /// Indicates whether to format the source code.
+        /// </param>
+        public string ToSourceCode(bool formatted = true) =>
+            Build().ToSourceCode(formatted);
+
+        /// <summary>
+        /// Returns the source code of the built namespace.
+        /// </summary>
+        public override string ToString() =>
+            ToSourceCode();
 
         internal Namespace Build()
         {
@@ -166,6 +199,13 @@ namespace SharpCode
                 .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
                 .MatchSome(item => throw new SyntaxException(
                     "A class defined under a namespace cannot have the access modifier " +
+                    $"'{item.AccessModifier.ToSourceCode()}'."));
+
+            _namespace.Structs.AddRange(_structs.Select(builder => builder.Build()));
+            _namespace.Structs
+                .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
+                .MatchSome(item => throw new SyntaxException(
+                    "A struct defined under a namespace cannot have the access modifier " +
                     $"'{item.AccessModifier.ToSourceCode()}'."));
 
             _namespace.Interfaces.AddRange(_interfaces.Select(builder => builder.Build()));

--- a/src/SharpCode/PropertyBuilder.cs
+++ b/src/SharpCode/PropertyBuilder.cs
@@ -221,7 +221,7 @@ namespace SharpCode
         /// </param>
         public PropertyBuilder WithSummary(string summary)
         {
-            _property.Summary = Option.Some(summary);
+            _property.Summary = Option.Some<string?>(summary);
             return this;
         }
 

--- a/src/SharpCode/StructBuilder.cs
+++ b/src/SharpCode/StructBuilder.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Linq;
+using Optional;
+using Optional.Collections;
+
+namespace SharpCode
+{
+    /// <summary>
+    /// Provides functionality for building structs. <see cref="StructBuilder"/> instances are <b>not</b>
+    /// immutable.
+    /// </summary>
+    public class StructBuilder
+    {
+        private readonly Struct _struct = new Struct();
+        private readonly List<ConstructorBuilder> _constructors = new List<ConstructorBuilder>();
+        private readonly List<FieldBuilder> _fields = new List<FieldBuilder>();
+        private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
+
+        internal StructBuilder()
+        {
+        }
+
+        internal StructBuilder(string name, AccessModifier accessModifier)
+        {
+            _struct.Name = name;
+            _struct.AccessModifier = accessModifier;
+        }
+
+        /// <summary>
+        /// Sets the access modifier of the struct.
+        /// </summary>
+        /// <param name="accessModifier">
+        /// The access modifier of the struct.
+        /// </param>
+        public StructBuilder WithAccessModifier(AccessModifier accessModifier)
+        {
+            _struct.AccessModifier = accessModifier;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name of the struct.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the struct.
+        /// </param>
+        public StructBuilder WithName(string name)
+        {
+            _struct.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds XML summary documentation to the struct.
+        /// </summary>
+        /// <param name="summary">
+        /// The content of the summary documentation.
+        /// </param>
+        public StructBuilder WithSummary(string summary)
+        {
+            _struct.Summary = Option.Some<string?>(summary);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a constructor to the struct.
+        /// </summary>
+        /// <param name="builder">
+        /// The configuration of the constructor.
+        /// </param>
+        public StructBuilder WithConstructor(ConstructorBuilder builder)
+        {
+            _constructors.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a field to the struct.
+        /// </summary>
+        /// <param name="builder">
+        /// The configuration of the field.
+        /// </param>
+        public StructBuilder WithField(FieldBuilder builder)
+        {
+            _fields.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of fields to the struct.
+        /// </summary>
+        /// <param name="builders">
+        /// A collection of fields.
+        /// </param>
+        public StructBuilder WithFields(IEnumerable<FieldBuilder> builders)
+        {
+            _fields.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of fields to the struct.
+        /// </summary>
+        /// <param name="builders">
+        /// A collection of fields.
+        /// </param>
+        public StructBuilder WithFields(params FieldBuilder[] builders)
+        {
+            _fields.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a property to the struct.
+        /// </summary>
+        /// <param name="builder">
+        /// The configuration of the property.
+        /// </param>
+        public StructBuilder WithProperty(PropertyBuilder builder)
+        {
+            _properties.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of properties to the struct.
+        /// </summary>
+        /// <param name="builders">
+        /// A collection of properties.
+        /// </param>
+        public StructBuilder WithProperties(IEnumerable<PropertyBuilder> builders)
+        {
+            _properties.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of properties to the struct.
+        /// </summary>
+        /// <param name="builders">
+        /// A collection of properties.
+        /// </param>
+        public StructBuilder WithProperties(params PropertyBuilder[] builders)
+        {
+            _properties.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an interface to the list of interfaces that the struct implements.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the interface that the struct implements.
+        /// </param>
+        public StructBuilder WithImplementedInterface(string name)
+        {
+            _struct.ImplementedInterfaces.Add(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of interfaces to the list of interfaces that the struct implements.
+        /// </summary>
+        /// <param name="names">
+        /// A collection with the names of interfaces that the struct implements.
+        /// </param>
+        public StructBuilder WithImplementedInterfaces(IEnumerable<string> names)
+        {
+            _struct.ImplementedInterfaces.AddRange(names);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of interfaces to the list of interfaces that the struct implements.
+        /// </summary>
+        /// <param name="names">
+        /// A collection with the names of interfaces that the struct implements.
+        /// </param>
+        public StructBuilder WithImplementedInterfaces(params string[] names)
+        {
+            _struct.ImplementedInterfaces.AddRange(names);
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the source code of the built struct.
+        /// </summary>
+        /// <param name="formatted">
+        /// Indicates whether to format the source code.
+        /// </param>
+        public string ToSourceCode(bool formatted = true) =>
+            Build().ToSourceCode(formatted);
+
+        /// <summary>
+        /// Returns the source code of the built struct.
+        /// </summary>
+        public override string ToString() =>
+            ToSourceCode();
+
+        internal Struct Build()
+        {
+            if (string.IsNullOrWhiteSpace(_struct.Name))
+            {
+                throw new MissingBuilderSettingException(
+                    "Providing the name of the struct is required when building a struct.");
+            }
+
+            _struct.ImplementedInterfaces
+                .FirstOrNone(x => string.IsNullOrWhiteSpace(x))
+                .MatchSome(_ => throw new MissingBuilderSettingException(
+                    "Providing the name of the interface is required when adding an implemented interface to a struct."));
+
+            _struct.Fields.AddRange(_fields.Select(field => field.Build()));
+            _struct.Properties.AddRange(_properties.Select(prop => prop.Build()));
+            _struct.Properties
+                .FirstOrNone(x => x.DefaultValue.HasValue)
+                .MatchSome(prop => throw new SyntaxException(
+                    "Default property values are not allowed in structs. (CS0573)"));
+
+            _struct.Constructors.AddRange(
+                _constructors.Select(ctor => ctor
+                    .WithName(_struct.Name!)
+                    .Build()));
+            _struct.Constructors
+                .FirstOrNone(x => !x.Parameters.Any())
+                .MatchSome(ctor => throw new SyntaxException(
+                    "Explicit parameterless contructors are not allowed in structs. (CS0568)"));
+
+            return _struct;
+        }
+  }
+}

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -29,7 +29,7 @@ namespace SharpCode
 
         public string? Name { get; set; }
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
     }
 
     internal class Property
@@ -42,7 +42,7 @@ namespace SharpCode
 
         public string? Name { get; set; }
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
 
         public Option<string> DefaultValue { get; set; } = Option.None<string>();
 
@@ -68,9 +68,9 @@ namespace SharpCode
 
         public string? ClassName { get; set; }
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
 
-        public List<Parameter> Parameters { get; set; } = new List<Parameter>();
+        public List<Parameter> Parameters { get; } = new List<Parameter>();
 
         public Option<IEnumerable<string>> BaseCallParameters { get; set; } = Option.None<IEnumerable<string>>();
     }
@@ -83,7 +83,7 @@ namespace SharpCode
 
         public string? Name { get; set; }
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
 
         public Option<string> InheritedClass { get; set; } = Option.None<string>();
 
@@ -96,13 +96,30 @@ namespace SharpCode
         public List<Constructor> Constructors { get; } = new List<Constructor>();
     }
 
+    internal class Struct
+    {
+        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
+        public string? Name { get; set; }
+
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
+
+        public List<string?> ImplementedInterfaces { get; } = new List<string?>();
+
+        public List<Constructor> Constructors { get; } = new List<Constructor>();
+
+        public List<Field> Fields { get; } = new List<Field>();
+
+        public List<Property> Properties { get; } = new List<Property>();
+    }
+
     internal class Interface
     {
         public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
 
         public string? Name { get; set; }
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
 
         public List<string> ImplementedInterfaces { get; } = new List<string>();
 
@@ -115,7 +132,7 @@ namespace SharpCode
 
         public Option<int> Value { get; set; } = Option.None<int>();
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
     }
 
     internal class Enumeration
@@ -124,7 +141,7 @@ namespace SharpCode
 
         public string? Name { get; set; }
 
-        public Option<string> Summary { get; set; } = Option.None<string>();
+        public Option<string?> Summary { get; set; } = Option.None<string?>();
 
         public bool IsFlag { get; set; }
 
@@ -138,6 +155,8 @@ namespace SharpCode
         public List<string> Usings { get; } = new List<string>();
 
         public List<Class> Classes { get; } = new List<Class>();
+
+        public List<Struct> Structs { get; } = new List<Struct>();
 
         public List<Interface> Interfaces { get; } = new List<Interface>();
 


### PR DESCRIPTION
This update adds support for generating `struct` structures.

## Structs are now supported

```csharp
Code.CreateStruct()
    .WithAccessModifier(AccessModifier.Public)
    .WithName("Position")
    .WithSummary("Represents an X/Y position.")
    .WithFields(
        Code.CreateField("int", "_x"),
        Code.CreateField("int", "_y"))
    .WithConstructor(Code.CreateConstructor()
        .WithParameter("int", "x", "_x")
        .WithParameter("int", "y", "_y"))
    .WithProperties(
        Code.CreateProperty("int", "X").WithGetter("_x").WithSetter("_x = value"),
        Code.CreateProperty("int", "Y").WithGetter("_y").WithSetter("_y = value"))
    .ToSourceCode();
// yields
/// <summary>
/// Represents an X/Y position.
/// </summary>
public struct Position
{
    private int _x;
    private int _y;
    public Position(int x, int y)
    {
        _x = x;
        _y = y;
    }

    public int X
    {
        get => _x;
        set => _x = value;
    }

    public int Y
    {
        get => _y;
        set => _y = value;
    }
}
```

## Additional changes

- additional unit tests for `NamespaceBuilder`