### PR TITLE
Output should not corrupt irrespective of documentation content

### DIFF
--- a/src/SharpCode.Test/StructBuilderTests.cs
+++ b/src/SharpCode.Test/StructBuilderTests.cs
@@ -64,7 +64,7 @@ namespace SharpCode.Test
         public void CreatingStruct_Works()
         {
             var generatedCode = Code.CreateStruct()
-                .WithSummary("Represents an X/Y position.")
+                .WithSummary("The {fields} represent an X/Y position.")
                 .WithAccessModifier(AccessModifier.ProtectedInternal)
                 .WithName("Position")
                 .WithImplementedInterface("IComparable")
@@ -82,7 +82,7 @@ namespace SharpCode.Test
 
             var expectedCode = @"
 /// <summary>
-/// Represents an X/Y position.
+/// The {fields} represent an X/Y position.
 /// </summary>
 protected internal struct Position : IComparable
 {


### PR DESCRIPTION
This happens because the placeholders are declared from a template.
This particular test fails for the struct builder. That's because it replaces the the documentation placeholder first.

```
Template.Replace("{documentation}", SummaryBlock(data.Summary))
```
The same test would pass for the class builder because it replaces the documentation placeholder at the very end.
However, changing the order would be a band-aid fix, because I might have a placeholder as part of a field summary for example.

A more permanent fix might be to refactor each of the parts, and use string interpolation to tie it together.
If you're feeling really adventurous, you can have the builder [generate a Roslyn AST](https://gist.github.com/cmendible/9b8c7d7598f1ab0bc7ab5d24b2622622), which would give you very flexible output generation.

Good job on the library!