### PR TITLE
Add introspection API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, task/code-coverage ]
+    branches: [ main, task/introspection ]
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, task/introspection ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introspection API via the new .HasMember() method, available on applicable structure builders
+- More null arguments sanitizing in public methods and consecutively more `ArgumentNullException` and `ArgumentException`, which are documented in the respective methods
+
+### Changed
+
+- Refactored the internal structures from `class` to `readonly struct`
+- Made better use of optionals and replaced some nullables
+
 ## [0.2.0] - 2020-10-05
 
 ### Added

--- a/src/SharpCode.Test/ClassBuilderTests.cs
+++ b/src/SharpCode.Test/ClassBuilderTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -266,11 +268,11 @@ public static class Config
                 () => Code.CreateClass().ToSourceCode(),
                 "Generating the source code for a class without setting the name should throw an exception.");
 
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateClass(name: null).ToSourceCode(),
                 "Generating the source for a class with null as a name should throw an exception.");
 
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateClass().WithName(null).ToSourceCode(),
                 "Generating the source for a class with null as a name should throw an exception.");
 
@@ -301,6 +303,44 @@ public static class Config
                     .WithConstructor(Code.CreateConstructor())
                     .ToSourceCode(),
                 "Generating the source code for a static class with multiple constructors should throw an exception.");
+        }
+
+        [Test]
+        public void ClassBuilder_WithProperties_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateClass("Test")
+                .WithProperties(new List<PropertyBuilder>
+                {
+                    Code.CreateProperty().WithType(typeof(int)).WithName("Count"),
+                    Code.CreateProperty().WithType(typeof(string)).WithName("Name"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateClass("Test")
+                .WithProperties(
+                    Code.CreateProperty().WithType(typeof(int)).WithName("Count"),
+                    Code.CreateProperty().WithType(typeof(string)).WithName("Name"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void ClassBuilder_ToSourceCode_ToString_YieldIdentical()
+        {
+            var toSourceCode = Code.CreateClass("Test")
+                .WithField(Code.CreateField("int", "_count"))
+                .WithConstructor(Code.CreateConstructor())
+                .WithProperty(Code.CreateProperty("string", "Name"))
+                .ToSourceCode();
+
+            var toString = Code.CreateClass("Test")
+                .WithField(Code.CreateField("int", "_count"))
+                .WithConstructor(Code.CreateConstructor())
+                .WithProperty(Code.CreateProperty("string", "Name"))
+                .ToString();
+
+            Assert.AreEqual(toSourceCode, toString);
         }
     }
 }

--- a/src/SharpCode.Test/EnumBuilderTests.cs
+++ b/src/SharpCode.Test/EnumBuilderTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -221,11 +223,11 @@ public enum Storage
                 () => Code.CreateEnum().ToSourceCode(),
                 "Generating the source code for an enum without setting the name should throw an exception.");
 
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateEnum(name: null).ToSourceCode(),
                 "Generating the source for an enum with null as a name should throw an exception.");
 
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateEnum().WithName(null).ToSourceCode(),
                 "Generating the source for an enum with null as a name should throw an exception.");
 
@@ -255,6 +257,34 @@ public enum Storage
                     Code.CreateEnumMember("Duplicate"))
                     .ToSourceCode(),
                 "Generating the source code for an enum with duplicate values should throw an exception.");
+        }
+
+        [Test]
+        public void EnumBuilder_WithMembers_ApisYieldIdenticalResults()
+        {
+            var enumerableApi = Code.CreateEnum("Test")
+                .WithMembers(new List<EnumMemberBuilder>
+                {
+                    Code.CreateEnumMember("None"),
+                    Code.CreateEnumMember("Some"),
+                })
+                .ToSourceCode();
+
+            var paramsApi = Code.CreateEnum("Test")
+                .WithMembers(
+                    Code.CreateEnumMember("None"),
+                    Code.CreateEnumMember("Some"))
+                .ToSourceCode();
+
+            Assert.AreEqual(enumerableApi, paramsApi);
+        }
+
+        [Test]
+        public void EnumBuilder_ToSourceCode_ToString_YieldIdentical()
+        {
+            var toSourceCode = Code.CreateEnum("Type").WithMember(Code.CreateEnumMember("Some")).ToSourceCode();
+            var toString = Code.CreateEnum("Type").WithMember(Code.CreateEnumMember("Some")).ToString();
+            Assert.AreEqual(toSourceCode, toString);
         }
     }
 }

--- a/src/SharpCode.Test/EnumMemberBuilderTests.cs
+++ b/src/SharpCode.Test/EnumMemberBuilderTests.cs
@@ -1,0 +1,43 @@
+using System;
+using NUnit.Framework;
+
+namespace SharpCode.Test
+{
+    [TestFixture]
+    public class EnumMemberBuilderTests
+    {
+        [Test]
+        public void CreatingEnumMember_WithoutRequiredSettings_Throws()
+        {
+            // --- WithName() API
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnumMember().Build(),
+                "Generating the source code for an enum member without setting the name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnumMember().WithName(string.Empty).Build(),
+                "Generating the source code for an enum member with an empty string as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateEnumMember().WithName("  ").Build(),
+                "Generating the source code for an enum member with whitespace name should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateEnumMember().WithName(null).Build(),
+                "Generating the source code for an enum member with null as name should throw an exception.");
+
+            // --- Shorthand API
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateEnumMember(name: null).Build(),
+                "Generating the source code for an enum member with null as name should throw an exception.");
+        }
+
+        [Test]
+        public void CreatingEnumMember_WithInvalidSummary_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateEnumMember().WithName("None").WithSummary(null).Build(),
+                "Generating the source code for an enum member with null as summary should throw an exception.");
+        }
+    }
+}

--- a/src/SharpCode.Test/FieldBuilderTests.cs
+++ b/src/SharpCode.Test/FieldBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -35,15 +36,58 @@ namespace SharpCode.Test
         }
 
         [Test]
-        public void CreateField_Throws_WhenRequiredSettingsNotProvided()
+        public void CreatingField_WithoutRequiredSettings_Throws()
         {
+            // --- WithName() API
             Assert.Throws<MissingBuilderSettingException>(
                 () => Code.CreateField().WithType("string").ToSourceCode(),
-                "Expected generating the source code for a field without setting the name to throw an exception.");
+                "Generating the source code for a field without setting the name should throw an exception.");
 
             Assert.Throws<MissingBuilderSettingException>(
-                () => Code.CreateField().WithName("_iHaveNoType").ToSourceCode(),
-                "Expected generating the source code for a field without setting the type to throw an exception.");
+                () => Code.CreateField().WithName(string.Empty).WithType("string").ToSourceCode(),
+                "Generating the source code for a field with an empty string as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateField().WithName("  ").WithType("string").ToSourceCode(),
+                "Generating the source code for a field with whitespace name should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateField().WithName(null).ToSourceCode(),
+                "Generating the source code for a field with null as name should throw an exception.");
+
+            // --- WithType() API
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateField().WithName("count").ToSourceCode(),
+                "Generating the source code for a field without setting the type should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateField().WithName("count").WithType(string.Empty).ToSourceCode(),
+                "Generating the source code for a field with an empty string as type should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateField().WithName("count").WithType("  ").ToSourceCode(),
+                "Generating the source code for a field with whitespace type should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateField().WithName("count").WithType((Type)null).ToSourceCode(),
+                "Generating the source code for a field with null as type should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateField().WithName("count").WithType((string)null).ToSourceCode(),
+                "Generating the source code for a field with null as type should throw an exception.");
+
+            // --- Shorthand API
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateField(name: null, type: "string").ToSourceCode(),
+                "Generating the source code for a field with null as name should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateField(name: "count", type: (Type)null).ToSourceCode(),
+                "Generating the source code for a field with null as type should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateField(name: "count", type: (string)null).ToSourceCode(),
+                "Generating the source code for a field with null as type should throw an exception.");
         }
 
         [Test]
@@ -66,6 +110,19 @@ private internal readonly string _name;
             ".Trim().WithUnixEOL();
 
             Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingField_WithInvalidSummary_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => Code.CreateField().WithSummary(null));
+        }
+
+        [Test]
+        public void FieldBuilder_ToSourceCode_ToString_YieldSame()
+        {
+            var builder = Code.CreateField(typeof(int), "_count", AccessModifier.ProtectedInternal);
+            Assert.AreEqual(builder.ToSourceCode(), builder.ToString());
         }
     }
 }

--- a/src/SharpCode.Test/IntrospectionTests.cs
+++ b/src/SharpCode.Test/IntrospectionTests.cs
@@ -1,0 +1,146 @@
+using System;
+using NUnit.Framework;
+
+namespace SharpCode.Test
+{
+    [TestFixture]
+    public class IntrospectionTests
+    {
+        [Test]
+        public void ClassBuilder_HasMember_WorksWithFields()
+        {
+            var builder = Code.CreateClass(name: "Test")
+                .WithFields(
+                    Code.CreateField("string", "_name"),
+                    Code.CreateField("bool", "_hasValue"));
+
+            Assert.IsTrue(builder.HasMember("_name"));
+            Assert.IsTrue(builder.HasMember("_name", MemberType.Field));
+
+            Assert.IsTrue(builder.HasMember("_HaSValUE", MemberType.Field));
+            Assert.IsFalse(builder.HasMember("_HaSValUE", MemberType.Field, comparison: StringComparison.Ordinal));
+
+            Assert.IsFalse(builder.HasMember("_hasValue", MemberType.Property));
+        }
+
+        [Test]
+        public void ClassBuilder_HasMember_WorksWithProperties()
+        {
+            var builder = Code.CreateClass(name: "Test")
+                .WithProperties(
+                    Code.CreateProperty("string", "Name"),
+                    Code.CreateProperty("bool", "HasValue"));
+
+            Assert.IsTrue(builder.HasMember("Name"));
+            Assert.IsTrue(builder.HasMember("Name", MemberType.Property));
+
+            Assert.IsTrue(builder.HasMember("HaSValUE", MemberType.Property));
+            Assert.IsFalse(builder.HasMember("HaSValUE", MemberType.Property, comparison: StringComparison.Ordinal));
+
+            Assert.IsFalse(builder.HasMember("Name", MemberType.Field));
+        }
+
+        [Test]
+        public void ClassBuilder_HasMember_WorksWithAnyMember()
+        {
+            var builder = Code.CreateClass(name: "Test")
+                .WithFields(
+                    Code.CreateField("string", "_name"),
+                    Code.CreateField("int", "_count"))
+                .WithProperties(
+                    Code.CreateProperty("string", "Name"),
+                    Code.CreateProperty("bool", "HasValue"));
+
+            Assert.IsTrue(builder.HasMember("_name"));
+            Assert.IsFalse(builder.HasMember("_name", MemberType.Property));
+
+            Assert.IsTrue(builder.HasMember("_count", MemberType.Field));
+            Assert.IsTrue(builder.HasMember("_COUNT", MemberType.Field));
+
+            Assert.IsTrue(builder.HasMember("Name"));
+            Assert.IsTrue(builder.HasMember("Name", MemberType.Property));
+            Assert.IsFalse(builder.HasMember("Name", MemberType.Field));
+
+            Assert.IsTrue(builder.HasMember("HaSValUE", MemberType.Property));
+            Assert.IsFalse(builder.HasMember("HaSValUE", MemberType.Field));
+        }
+
+        [Test]
+        public void EnumBuilder_HasMember_Works()
+        {
+            var builder = Code.CreateEnum(name: "Test").WithMembers(
+                Code.CreateEnumMember("None"),
+                Code.CreateEnumMember("Some"));
+
+            Assert.IsTrue(builder.HasMember("none"));
+            Assert.IsTrue(builder.HasMember("some"));
+
+            Assert.IsFalse(builder.HasMember("any"));
+            Assert.IsFalse(builder.HasMember("NONE", StringComparison.Ordinal));
+        }
+
+        [Test]
+        public void StructBuilder_HasMember_Works()
+        {
+            var builder = Code.CreateStruct(name: "Test")
+                .WithFields(
+                    Code.CreateField("int", "_x"),
+                    Code.CreateField("int", "_y"),
+                    Code.CreateField("string", "_title"))
+                .WithProperties(
+                    Code.CreateProperty("int", "X").WithGetter("_x").WithSetter("_x"),
+                    Code.CreateProperty("int", "Y").WithGetter("_y").WithSetter("_y"),
+                    Code.CreateProperty("string", "Title").WithGetter("_title").WithSetter("_title"));
+
+            Assert.IsTrue(builder.HasMember("_x"));
+            Assert.IsTrue(builder.HasMember("_y"));
+            Assert.IsTrue(builder.HasMember("_title"));
+            Assert.IsTrue(builder.HasMember("_x", MemberType.Field));
+            Assert.IsTrue(builder.HasMember("_y", MemberType.Field));
+            Assert.IsTrue(builder.HasMember("_title", MemberType.Field));
+
+            Assert.IsTrue(builder.HasMember("X"));
+            Assert.IsTrue(builder.HasMember("Y"));
+            Assert.IsTrue(builder.HasMember("Title"));
+            Assert.IsTrue(builder.HasMember("X", MemberType.Property));
+            Assert.IsTrue(builder.HasMember("Y", MemberType.Property));
+            Assert.IsTrue(builder.HasMember("Title", MemberType.Property));
+
+            Assert.IsFalse(builder.HasMember("_x", MemberType.Property));
+            Assert.IsFalse(builder.HasMember("_y", MemberType.Property));
+            Assert.IsFalse(builder.HasMember("_title", MemberType.Property));
+
+            Assert.IsFalse(builder.HasMember("X", MemberType.Field));
+            Assert.IsFalse(builder.HasMember("Y", MemberType.Field));
+            Assert.IsFalse(builder.HasMember("Title", MemberType.Field));
+        }
+
+        [Test]
+        public void InterfaceBuilder_HasMember_Works()
+        {
+            var builder = Code.CreateInterface("ITest").WithProperties(
+                Code.CreateProperty(typeof(string), "Prefix"),
+                Code.CreateProperty(typeof(string), "Suffix"),
+                Code.CreateProperty(typeof(string), "Name"));
+
+            Assert.IsTrue(builder.HasMember("Prefix"));
+            Assert.IsTrue(builder.HasMember("Suffix", MemberType.Property));
+            Assert.IsFalse(builder.HasMember("Name", MemberType.Field));
+        }
+
+        [Test]
+        public void NamespaceBuilder_HasMember_Works()
+        {
+            var builder = Code.CreateNamespace("Container")
+                .WithClass(Code.CreateClass("TestClass"))
+                .WithEnum(Code.CreateEnum("TestEnum"))
+                .WithInterface(Code.CreateInterface("ITest"))
+                .WithStruct(Code.CreateStruct("TestStruct"));
+
+            Assert.IsTrue(builder.HasMember("TestClass", MemberType.Class));
+            Assert.IsTrue(builder.HasMember("TestEnum", MemberType.Enum));
+            Assert.IsTrue(builder.HasMember("ITest", MemberType.Interface));
+            Assert.IsTrue(builder.HasMember("TestStruct", MemberType.Struct));
+        }
+    }
+}

--- a/src/SharpCode.Test/IntrospectionTests.cs
+++ b/src/SharpCode.Test/IntrospectionTests.cs
@@ -132,11 +132,13 @@ namespace SharpCode.Test
         public void NamespaceBuilder_HasMember_Works()
         {
             var builder = Code.CreateNamespace("Container")
+                .WithUsing("System.Collections.Generic")
                 .WithClass(Code.CreateClass("TestClass"))
                 .WithEnum(Code.CreateEnum("TestEnum"))
                 .WithInterface(Code.CreateInterface("ITest"))
                 .WithStruct(Code.CreateStruct("TestStruct"));
 
+            Assert.IsTrue(builder.HasMember("System.Collections.Generic"));
             Assert.IsTrue(builder.HasMember("TestClass", MemberType.Class));
             Assert.IsTrue(builder.HasMember("TestEnum", MemberType.Enum));
             Assert.IsTrue(builder.HasMember("ITest", MemberType.Interface));

--- a/src/SharpCode.Test/NamespaceBuilderTests.cs
+++ b/src/SharpCode.Test/NamespaceBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -230,10 +231,10 @@ namespace GeneratedCode
                 () => Code.CreateNamespace().ToSourceCode(),
                 "Generating the source code for a namespace without a name should throw an exception.");
 
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateNamespace(name: null).ToSourceCode(),
                 "Generating the source code for a namespace with null as a name should throw an exception.");
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateNamespace().WithName(null).ToSourceCode(),
                 "Generating the source code for a namespace with null as a name should throw an exception.");
 

--- a/src/SharpCode.Test/PropertyBuilderTests.cs
+++ b/src/SharpCode.Test/PropertyBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -43,6 +44,12 @@ public string Username
             ".Trim().WithUnixEOL();
 
             Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreatingProperty_WithInvalidSummary_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => Code.CreateProperty().WithSummary(null));
         }
 
         [Test]
@@ -103,15 +110,58 @@ private string EmptyString
         }
 
         [Test]
-        public void CreateProperty_Throws_WhenRequiredSettingsNotProvided()
+        public void CreatingProperty_WithoutRequiredSettings_Throws()
         {
+            // --- WithName() API
             Assert.Throws<MissingBuilderSettingException>(
                 () => Code.CreateProperty().WithType("string").ToSourceCode(),
-                "Expected generating the source code for a property without setting the name to throw an exception.");
+                "Generating the source code for a property without setting the name should throw an exception.");
 
             Assert.Throws<MissingBuilderSettingException>(
-                () => Code.CreateProperty().WithName("IHaveNoType").ToSourceCode(),
-                "Expected generating the source code for a property without setting the type to throw an exception.");
+                () => Code.CreateProperty().WithName(string.Empty).WithType("string").ToSourceCode(),
+                "Generating the source code for a property with an empty string as name should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateProperty().WithName("  ").WithType("string").ToSourceCode(),
+                "Generating the source code for a property with whitespace name should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateProperty().WithName(null).ToSourceCode(),
+                "Generating the source code for a property with null as name should throw an exception.");
+
+            // --- WithType() API
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateProperty().WithName("count").ToSourceCode(),
+                "Generating the source code for a property without setting the type should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateProperty().WithName("count").WithType(string.Empty).ToSourceCode(),
+                "Generating the source code for a property with an empty string as type should throw an exception.");
+
+            Assert.Throws<MissingBuilderSettingException>(
+                () => Code.CreateProperty().WithName("count").WithType("  ").ToSourceCode(),
+                "Generating the source code for a property with whitespace type should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateProperty().WithName("count").WithType((Type)null).ToSourceCode(),
+                "Generating the source code for a property with null as type should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateProperty().WithName("count").WithType((string)null).ToSourceCode(),
+                "Generating the source code for a property with null as type should throw an exception.");
+
+            // --- Shorthand API
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateProperty(name: null, type: "string").ToSourceCode(),
+                "Generating the source code for a property with null as name should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateProperty(name: "count", type: (Type)null).ToSourceCode(),
+                "Generating the source code for a property with null as type should throw an exception.");
+
+            Assert.Throws<ArgumentNullException>(
+                () => Code.CreateProperty(name: "count", type: (string)null).ToSourceCode(),
+                "Generating the source code for a property with null as type should throw an exception.");
         }
 
         [Test]
@@ -236,6 +286,19 @@ public static int Zero
                 expectedCode,
                 generatedCode,
                 "Failed case: static property with auto implemented getter and default value");
+        }
+
+        [Test]
+        public void CreatingProperty_WithInvalidDefaultValue_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => Code.CreateProperty().WithDefaultValue(null));
+        }
+
+        [Test]
+        public void PropertyBuilder_ToSourceCode_ToString_YieldSame()
+        {
+            var builder = Code.CreateProperty(typeof(string), "Name", AccessModifier.ProtectedInternal);
+            Assert.AreEqual(builder.ToSourceCode(), builder.ToString());
         }
     }
 }

--- a/src/SharpCode.Test/StructBuilderTests.cs
+++ b/src/SharpCode.Test/StructBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -13,7 +14,7 @@ namespace SharpCode.Test
                 () => Code.CreateStruct().ToSourceCode(),
                 "Generating the source code for a struct without a name should throw an exception.");
 
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateStruct().WithName(null).ToSourceCode(),
                 "Generating the source code for a struct with null as name should throw an exception.");
 
@@ -37,7 +38,7 @@ namespace SharpCode.Test
         [Test]
         public void CreatingStruct_WithImplementedInterface_WithInvalidName_Throws()
         {
-            Assert.Throws<MissingBuilderSettingException>(
+            Assert.Throws<ArgumentNullException>(
                 () => Code.CreateStruct(name: "Test").WithImplementedInterface(null).ToSourceCode(),
                 "Generating the source code for a struct with null as name should throw an exception.");
 

--- a/src/SharpCode/ClassBuilder.cs
+++ b/src/SharpCode/ClassBuilder.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Optional;
+using Optional.Unsafe;
 
 namespace SharpCode
 {
@@ -10,7 +12,6 @@ namespace SharpCode
     /// </summary>
     public class ClassBuilder
     {
-        private readonly Class _class = new Class();
         private readonly List<FieldBuilder> _fields = new List<FieldBuilder>();
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
         private readonly List<ConstructorBuilder> _constructors = new List<ConstructorBuilder>();
@@ -21,43 +22,70 @@ namespace SharpCode
 
         internal ClassBuilder(AccessModifier accessModifier, string name)
         {
-            _class.AccessModifier = accessModifier;
-            _class.Name = name;
+            Class = new Class(
+                accessModifier: accessModifier,
+                name: Option.Some(name));
         }
+
+        internal Class Class { get; private set; } = new Class(AccessModifier.Public);
 
         /// <summary>
         /// Sets the access modifier of the class being built.
         /// </summary>
         public ClassBuilder WithAccessModifier(AccessModifier accessModifier)
         {
-            _class.AccessModifier = accessModifier;
+            Class = Class.With(accessModifier: Option.Some(accessModifier));
             return this;
         }
 
         /// <summary>
         /// Sets the name of the class being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithName(string name)
         {
-            _class.Name = name;
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Class = Class.With(name: Option.Some(name));
             return this;
         }
 
         /// <summary>
         /// Sets the class that the class being built inherits from.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithInheritedClass(string name)
         {
-            _class.InheritedClass = Option.Some(name);
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Class = Class.With(inheritedClass: Option.Some(name));
             return this;
         }
 
         /// <summary>
         /// Adds an interface to the list of interfaces that the class being built implements.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithImplementedInterface(string name)
         {
-            _class.ImplementedInterfaces.Add(name);
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Class.ImplementedInterfaces.Add(name);
             return this;
         }
 
@@ -67,17 +95,33 @@ namespace SharpCode
         /// <param name="summary">
         /// The content of the summary documentation.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="summary"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithSummary(string summary)
         {
-            _class.Summary = Option.Some<string?>(summary);
+            if (summary is null)
+            {
+                throw new ArgumentNullException(nameof(summary));
+            }
+
+            Class = Class.With(summary: Option.Some(summary));
             return this;
         }
 
         /// <summary>
         /// Adds a field to the class being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithField(FieldBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _fields.Add(builder);
             return this;
         }
@@ -85,8 +129,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of fields to the class being built.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithFields(params FieldBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException($"On of the {nameof(builders)} parameter values is null.");
+            }
+
             _fields.AddRange(builders);
             return this;
         }
@@ -94,8 +146,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a property to the class being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithProperty(PropertyBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _properties.Add(builder);
             return this;
         }
@@ -103,8 +163,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of properties to the class being built.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithProperties(params PropertyBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException($"One of the {nameof(builders)} parameter values is null.");
+            }
+
             _properties.AddRange(builders);
             return this;
         }
@@ -112,8 +180,24 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of properties to the class being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithProperties(IEnumerable<PropertyBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException($"One of the {nameof(builders)} parameter values is null.");
+            }
+
             _properties.AddRange(builders);
             return this;
         }
@@ -121,8 +205,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a constructor to the class being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public ClassBuilder WithConstructor(ConstructorBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _constructors.Add(builder);
             return this;
         }
@@ -135,8 +227,54 @@ namespace SharpCode
         /// </param>
         public ClassBuilder MakeStatic(bool makeStatic = true)
         {
-            _class.IsStatic = makeStatic;
+            Class = Class.With(isStatic: Option.Some(makeStatic));
             return this;
+        }
+
+        /// <summary>
+        /// Checks whether the described member exists in the class structure.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the member.
+        /// </param>
+        /// <param name="memberType">
+        /// The type of the member. By default all members will be taken into account.
+        /// </param>
+        /// <param name="accessModifier">
+        /// The access modifier of the member. By default all access modifiers will be taken into account.
+        /// </param>
+        /// <param name="comparison">
+        /// The comparision type to be performed when comparing the described name against the names of the actual
+        /// members. By default casing is ignored.
+        /// </param>
+        public bool HasMember(
+            string name,
+            MemberType? memberType = default,
+            AccessModifier? accessModifier = default,
+            StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            if (memberType == MemberType.Field)
+            {
+                return _fields
+                    .Where(x => !accessModifier.HasValue || x.Field.AccessModifier == accessModifier)
+                    .Any(x => x.Field.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (memberType == MemberType.Property)
+            {
+                return _properties
+                    .Where(x => !accessModifier.HasValue || x.Property.AccessModifier == accessModifier)
+                    .Any(x => x.Property.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (!memberType.HasValue)
+            {
+                // Lookup all possible members
+                return HasMember(name, MemberType.Field, accessModifier, comparison) ||
+                    HasMember(name, MemberType.Property, accessModifier, comparison);
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -145,6 +283,12 @@ namespace SharpCode
         /// <param name="formatted">
         /// Indicates whether to format the source code.
         /// </param>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public string ToSourceCode(bool formatted = true)
         {
             return Build().ToSourceCode(formatted);
@@ -153,6 +297,12 @@ namespace SharpCode
         /// <summary>
         /// Returns the source code of the built class.
         /// </summary>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public override string ToString()
         {
             return ToSourceCode();
@@ -160,25 +310,25 @@ namespace SharpCode
 
         internal Class Build()
         {
-            if (string.IsNullOrWhiteSpace(_class.Name))
+            if (string.IsNullOrWhiteSpace(Class.Name.ValueOrDefault()))
             {
                 throw new MissingBuilderSettingException(
                     "Providing the name of the class is required when building a class.");
             }
-            else if (_class.IsStatic && _constructors.Count > 1)
+            else if (Class.IsStatic && _constructors.Count > 1)
             {
                 throw new SyntaxException("Static classes can have only 1 constructor.");
             }
 
-            _class.Fields.AddRange(_fields.Select(builder => builder.Build()));
-            _class.Properties.AddRange(_properties.Select(builder => builder.Build()));
-            _class.Constructors.AddRange(
+            Class.Fields.AddRange(_fields.Select(builder => builder.Build()));
+            Class.Properties.AddRange(_properties.Select(builder => builder.Build()));
+            Class.Constructors.AddRange(
                 _constructors.Select(builder => builder
-                    .WithName(_class.Name!)
-                    .MakeStatic(_class.IsStatic)
+                    .WithName(Class.Name.ValueOrFailure())
+                    .MakeStatic(Class.IsStatic)
                     .Build()));
 
-            return _class;
+            return Class;
         }
     }
 }

--- a/src/SharpCode/Code.cs
+++ b/src/SharpCode/Code.cs
@@ -21,8 +21,13 @@ namespace SharpCode
         /// <param name="name">
         /// The name of the namespace. Used as-is.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public static NamespaceBuilder CreateNamespace(string name) =>
-            new NamespaceBuilder(name);
+            name is null
+            ? throw new ArgumentNullException(nameof(name))
+            : new NamespaceBuilder(name);
 
         /// <summary>
         /// Creates a new <see cref="EnumBuilder"/> instance for building enums.
@@ -41,8 +46,13 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access modifier of the enum.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public static EnumBuilder CreateEnum(string name, AccessModifier accessModifier = AccessModifier.Public) =>
-            new EnumBuilder(name, accessModifier);
+            name is null
+            ? throw new ArgumentNullException(nameof(name))
+            : new EnumBuilder(name, accessModifier);
 
         /// <summary>
         /// Creates a new <see cref="EnumMemberBuilder"/> instance for building enum members.
@@ -64,8 +74,13 @@ namespace SharpCode
         /// members to ensure correct functionality. Flags enums for which no member has an explicit value will
         /// auto-generate appropriate values for each member.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public static EnumMemberBuilder CreateEnumMember(string name, int? value = null) =>
-            new EnumMemberBuilder(name, value.ToOption());
+            name is null
+            ? throw new ArgumentNullException(nameof(name))
+            : new EnumMemberBuilder(name, value.ToOption());
 
         /// <summary>
         /// Creates a new <see cref="InterfaceBuilder"/> instance for building interface structures.
@@ -84,10 +99,15 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access modifier of the interface.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public static InterfaceBuilder CreateInterface(
             string name,
             AccessModifier accessModifier = AccessModifier.Public) =>
-            new InterfaceBuilder(name, accessModifier);
+            name is null
+            ? throw new ArgumentNullException(nameof(name))
+            : new InterfaceBuilder(name, accessModifier);
 
         /// <summary>
         /// Creates a new <see cref="ClassBuilder"/> instance for building class structures.
@@ -106,8 +126,13 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access modifier of the class.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public static ClassBuilder CreateClass(string name, AccessModifier accessModifier = AccessModifier.Public) =>
-            new ClassBuilder(accessModifier, name);
+            name is null
+            ? throw new ArgumentNullException(nameof(name))
+            : new ClassBuilder(accessModifier, name);
 
         /// <summary>
         /// Creates a new <see cref="StructBuilder"/> instance for building structs.
@@ -126,8 +151,13 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access modifier of the struct.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public static StructBuilder CreateStruct(string name, AccessModifier accessModifier = AccessModifier.Public) =>
-            new StructBuilder(name, accessModifier);
+            name is null
+            ? throw new ArgumentNullException(nameof(name))
+            : new StructBuilder(name, accessModifier);
 
         /// <summary>
         /// Creates a new <see cref="FieldBuilder"/> instance for building fields.
@@ -149,11 +179,25 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access of modifier of the field.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// If the specified <paramref name="type"/> and/or <paramref name="name"/> are <c>null</c>.
+        /// </exception>
         public static FieldBuilder CreateField(
             string type,
             string name,
-            AccessModifier accessModifier = AccessModifier.Private) =>
-            new FieldBuilder(accessModifier, type, name);
+            AccessModifier accessModifier = AccessModifier.Private)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            else if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            return new FieldBuilder(accessModifier, type, name);
+        }
 
         /// <summary>
         /// Creates a new pre-configured <see cref="FieldBuilder"/> instance for building fields. Configures the
@@ -170,11 +214,25 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access of modifier of the field.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// If the specified <paramref name="type"/> and/or <paramref name="name"/> are <c>null</c>.
+        /// </exception>
         public static FieldBuilder CreateField(
             Type type,
             string name,
-            AccessModifier accessModifier = AccessModifier.Private) =>
-            new FieldBuilder(accessModifier, type, name);
+            AccessModifier accessModifier = AccessModifier.Private)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            else if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            return new FieldBuilder(accessModifier, type, name);
+        }
 
         /// <summary>
         /// Creates a new <see cref="ConstructorBuilder"/> instance for building constructors.
@@ -202,11 +260,25 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access of modifier of the property.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// If the specified <paramref name="type"/> and/or <paramref name="name"/> are <c>null</c>.
+        /// </exception>
         public static PropertyBuilder CreateProperty(
             string type,
             string name,
-            AccessModifier accessModifier = AccessModifier.Public) =>
-            new PropertyBuilder(accessModifier, type, name);
+            AccessModifier accessModifier = AccessModifier.Public)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            else if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            return new PropertyBuilder(accessModifier, type, name);
+        }
 
         /// <summary>
         /// Creates a new pre-configured <see cref="PropertyBuilder"/> instance for building properties. Configures the
@@ -224,10 +296,24 @@ namespace SharpCode
         /// <param name="accessModifier">
         /// The access of modifier of the property.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// If the specified <paramref name="type"/> and/or <paramref name="name"/> are <c>null</c>.
+        /// </exception>
         public static PropertyBuilder CreateProperty(
             Type type,
             string name,
-            AccessModifier accessModifier = AccessModifier.Public) =>
-            new PropertyBuilder(accessModifier, type, name);
+            AccessModifier accessModifier = AccessModifier.Public)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            else if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            return new PropertyBuilder(accessModifier, type, name);
+        }
     }
 }

--- a/src/SharpCode/EnumBuilder.cs
+++ b/src/SharpCode/EnumBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Optional;
 using Optional.Collections;
+using Optional.Unsafe;
 
 namespace SharpCode
 {
@@ -12,7 +13,6 @@ namespace SharpCode
     /// </summary>
     public class EnumBuilder
     {
-        private readonly Enumeration _enumeration = new Enumeration();
         private readonly List<EnumMemberBuilder> _members = new List<EnumMemberBuilder>();
 
         internal EnumBuilder()
@@ -21,33 +21,50 @@ namespace SharpCode
 
         internal EnumBuilder(string name, AccessModifier accessModifier)
         {
-            _enumeration.Name = name;
-            _enumeration.AccessModifier = accessModifier;
+            Enumeration = new Enumeration(accessModifier, name: Option.Some(name));
         }
+
+        internal Enumeration Enumeration { get; private set; } = new Enumeration(AccessModifier.Public);
 
         /// <summary>
         /// Sets the access modifier of the enum being built.
         /// </summary>
         public EnumBuilder WithAccessModifier(AccessModifier accessModifier)
         {
-            _enumeration.AccessModifier = accessModifier;
+            Enumeration = Enumeration.With(accessModifier: Option.Some(accessModifier));
             return this;
         }
 
         /// <summary>
         /// Sets the name of the enum being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public EnumBuilder WithName(string name)
         {
-            _enumeration.Name = name;
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Enumeration = Enumeration.With(name: Option.Some(name));
             return this;
         }
 
         /// <summary>
         /// Adds a member to the enum being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public EnumBuilder WithMember(EnumMemberBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _members.Add(builder);
             return this;
         }
@@ -55,8 +72,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of members to the enum being built.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public EnumBuilder WithMembers(params EnumMemberBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _members.AddRange(builders);
             return this;
         }
@@ -64,8 +89,24 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of members to the enum being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public EnumBuilder WithMembers(IEnumerable<EnumMemberBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _members.AddRange(builders);
             return this;
         }
@@ -80,7 +121,7 @@ namespace SharpCode
         /// </param>
         public EnumBuilder MakeFlagsEnum(bool makeFlagsEnum = true)
         {
-            _enumeration.IsFlag = makeFlagsEnum;
+            Enumeration = Enumeration.With(isFlag: Option.Some(makeFlagsEnum));
             return this;
         }
 
@@ -90,11 +131,34 @@ namespace SharpCode
         /// <param name="summary">
         /// The content of the summary documentation.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="summary"/> is <c>null</c>.
+        /// </exception>
         public EnumBuilder WithSummary(string summary)
         {
-            _enumeration.Summary = Option.Some<string?>(summary);
+            if (summary is null)
+            {
+                throw new ArgumentNullException(nameof(summary));
+            }
+
+            Enumeration = Enumeration.With(summary: Option.Some(summary));
             return this;
         }
+
+        /// <summary>
+        /// Checks whether the described member exists in the enum structure.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the member.
+        /// </param>
+        /// <param name="comparison">
+        /// The comparision type to be performed when comparing the described name against the names of the actual
+        /// members. By default casing is ignored.
+        /// </param>
+        public bool HasMember(
+            string name,
+            StringComparison comparison = StringComparison.InvariantCultureIgnoreCase) =>
+            _members.Any(x => x.EnumerationMember.Name.Exists(n => n.Equals(name, comparison)));
 
         /// <summary>
         /// Returns the source code of the built enum.
@@ -102,41 +166,53 @@ namespace SharpCode
         /// <param name="formatted">
         /// Indicates whether to format the source code.
         /// </param>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public string ToSourceCode(bool formatted = true) =>
             Build().ToSourceCode(formatted);
 
         /// <summary>
         /// Returns the source code of the built enum.
         /// </summary>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public override string ToString() =>
             ToSourceCode();
 
         internal Enumeration Build()
         {
-            if (string.IsNullOrWhiteSpace(_enumeration.Name))
+            if (string.IsNullOrWhiteSpace(Enumeration.Name.ValueOr(string.Empty)))
             {
                 throw new MissingBuilderSettingException(
                     "Providing the name of the enum is required when building an enum.");
             }
 
-            _enumeration.Members.AddRange(_members.Select(x => x.Build()));
-            _enumeration.Members
-                .GroupBy(x => x.Name)
+            if (Enumeration.IsFlag && _members.All(x => !x.EnumerationMember.Value.HasValue))
+            {
+                for (var i = 0; i < _members.Count; i++)
+                {
+                    _members[i] = _members[i].WithValue(i == 0 ? 0 : (int)Math.Pow(2, i - 1));
+                }
+            }
+
+            Enumeration.Members.AddRange(_members.Select(x => x.Build()));
+            Enumeration.Members
+                .GroupBy(x => x.Name.ValueOrFailure())
                 .Where(x => x.AtLeast(2))
                 .Select(x => x.Key)
                 .FirstOrNone()
                 .MatchSome(duplicateMemberName => throw new SyntaxException(
-                    $"The enum '{_enumeration.Name}' already contains a definition for '{duplicateMemberName}'."));
+                    $"The enum '{Enumeration.Name}' already contains a definition for '{duplicateMemberName}'."));
 
-            if (_enumeration.IsFlag && _enumeration.Members.All(x => !x.Value.HasValue))
-            {
-                for (var i = 0; i < _enumeration.Members.Count; i++)
-                {
-                    _enumeration.Members[i].Value = Option.Some(i == 0 ? 0 : (int)Math.Pow(2, i - 1));
-                }
-            }
-
-            return _enumeration;
+            return Enumeration;
         }
     }
 }

--- a/src/SharpCode/NamespaceBuilder.cs
+++ b/src/SharpCode/NamespaceBuilder.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Optional;
 using Optional.Collections;
 
 namespace SharpCode
@@ -17,7 +19,6 @@ namespace SharpCode
             AccessModifier.Public,
         };
 
-        private readonly Namespace _namespace = new Namespace();
         private readonly List<ClassBuilder> _classes = new List<ClassBuilder>();
         private readonly List<StructBuilder> _structs = new List<StructBuilder>();
         private readonly List<InterfaceBuilder> _interfaces = new List<InterfaceBuilder>();
@@ -29,15 +30,25 @@ namespace SharpCode
 
         internal NamespaceBuilder(string name)
         {
-            _namespace.Name = name;
+            Namespace = new Namespace(name: Option.Some(name));
         }
+
+        internal Namespace Namespace { get; private set; } = new Namespace(name: Option.None<string>());
 
         /// <summary>
         /// Sets the name of the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithName(string name)
         {
-            _namespace.Name = name;
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Namespace = Namespace.With(name: Option.Some(name));
             return this;
         }
 
@@ -48,35 +59,75 @@ namespace SharpCode
         /// The using directive to be added, for example <c>"System"</c> or <c>"System.Collections.Generic"</c>
         /// The semi-colon at the end is optional.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="usingDirective"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithUsing(string usingDirective)
         {
-            _namespace.Usings.Add(usingDirective.Replace(";", string.Empty));
+            if (usingDirective is null)
+            {
+                throw new ArgumentNullException(nameof(usingDirective));
+            }
+
+            Namespace.Usings.Add(usingDirective.Replace(";", string.Empty));
             return this;
         }
 
         /// <summary>
-        /// Adds a class definition to the namespace being built.
+        /// Adds a class to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithClass(ClassBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _classes.Add(builder);
             return this;
         }
 
         /// <summary>
-        /// Adds a bunch of class definitions to the namespace being built.
+        /// Adds a bunch of classes to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithClasses(params ClassBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException($"One of the {nameof(builders)} parameter values is null.");
+            }
+
             _classes.AddRange(builders);
             return this;
         }
 
         /// <summary>
-        /// Adds a bunch of class definitions to the namespace being built.
+        /// Adds a bunch of classes to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithClasses(IEnumerable<ClassBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _classes.AddRange(builders);
             return this;
         }
@@ -84,8 +135,19 @@ namespace SharpCode
         /// <summary>
         /// Adds an interface definition to the namespace being built.
         /// </summary>
+        /// <param name="builder">
+        /// The configuration of the interface.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithInterface(InterfaceBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _interfaces.Add(builder);
             return this;
         }
@@ -93,8 +155,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of interface definitions to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithInterfaces(params InterfaceBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _interfaces.AddRange(builders);
             return this;
         }
@@ -102,8 +172,24 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of interface definitions to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithInterfaces(IEnumerable<InterfaceBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _interfaces.AddRange(builders);
             return this;
         }
@@ -111,8 +197,19 @@ namespace SharpCode
         /// <summary>
         /// Adds an enum definition to the namespace being built.
         /// </summary>
+        /// <param name="builder">
+        /// The configuration of the enum.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithEnum(EnumBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _enums.Add(builder);
             return this;
         }
@@ -120,8 +217,16 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of enum definitions to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithEnums(params EnumBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _enums.AddRange(builders);
             return this;
         }
@@ -129,8 +234,24 @@ namespace SharpCode
         /// <summary>
         /// Adds a bunch of enum definitions to the namespace being built.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithEnums(IEnumerable<EnumBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _enums.AddRange(builders);
             return this;
         }
@@ -141,8 +262,16 @@ namespace SharpCode
         /// <param name="builder">
         /// The configuration of the struct.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithStruct(StructBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _structs.Add(builder);
             return this;
         }
@@ -153,8 +282,16 @@ namespace SharpCode
         /// <param name="builders">
         /// A collection of structs which will be added to the namespace.
         /// </param>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithStructs(params StructBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _structs.AddRange(builders);
             return this;
         }
@@ -165,10 +302,87 @@ namespace SharpCode
         /// <param name="builders">
         /// A collection of structs which will be added to the namespace.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public NamespaceBuilder WithStructs(IEnumerable<StructBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _structs.AddRange(builders);
             return this;
+        }
+
+        /// <summary>
+        /// Checks whether the described member exists in the namespace structure.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the member.
+        /// </param>
+        /// <param name="memberType">
+        /// The type of the member. By default all members will be taken into account.
+        /// </param>
+        /// <param name="accessModifier">
+        /// The access modifier of the member. By default all access modifiers will be taken into account.
+        /// </param>
+        /// <param name="comparison">
+        /// The comparision type to be performed when comparing the described name against the names of the actual
+        /// members. By default casing is ignored.
+        /// </param>
+        public bool HasMember(
+            string name,
+            MemberType? memberType = default,
+            AccessModifier? accessModifier = default,
+            StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            if (memberType == MemberType.Class)
+            {
+                return _classes
+                    .Where(x => !accessModifier.HasValue || x.Class.AccessModifier == accessModifier)
+                    .Any(x => x.Class.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (memberType == MemberType.Enum)
+            {
+                return _enums
+                    .Where(x => !accessModifier.HasValue || x.Enumeration.AccessModifier == accessModifier)
+                    .Any(x => x.Enumeration.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (memberType == MemberType.Interface)
+            {
+                return _interfaces
+                    .Where(x => !accessModifier.HasValue || x.Interface.AccessModifier == accessModifier)
+                    .Any(x => x.Interface.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (memberType == MemberType.Struct)
+            {
+                return _structs
+                    .Where(x => !accessModifier.HasValue || x.Struct.AccessModifier == accessModifier)
+                    .Any(x => x.Struct.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (!memberType.HasValue)
+            {
+                return HasMember(name, MemberType.Class, accessModifier, comparison) ||
+                    HasMember(name, MemberType.Enum, accessModifier, comparison) ||
+                    HasMember(name, MemberType.Interface, accessModifier, comparison) ||
+                    HasMember(name, MemberType.Struct, accessModifier, comparison);
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -177,52 +391,64 @@ namespace SharpCode
         /// <param name="formatted">
         /// Indicates whether to format the source code.
         /// </param>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public string ToSourceCode(bool formatted = true) =>
             Build().ToSourceCode(formatted);
 
         /// <summary>
         /// Returns the source code of the built namespace.
         /// </summary>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public override string ToString() =>
             ToSourceCode();
 
         internal Namespace Build()
         {
-            if (string.IsNullOrWhiteSpace(_namespace.Name))
+            if (string.IsNullOrWhiteSpace(Namespace.Name.ValueOr(string.Empty)))
             {
                 throw new MissingBuilderSettingException(
                     "Providing the name of the namespace is required when building a namespace.");
             }
 
-            _namespace.Classes.AddRange(_classes.Select(builder => builder.Build()));
-            _namespace.Classes
+            Namespace.Classes.AddRange(_classes.Select(builder => builder.Build()));
+            Namespace.Classes
                 .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
                 .MatchSome(item => throw new SyntaxException(
                     "A class defined under a namespace cannot have the access modifier " +
                     $"'{item.AccessModifier.ToSourceCode()}'."));
 
-            _namespace.Structs.AddRange(_structs.Select(builder => builder.Build()));
-            _namespace.Structs
+            Namespace.Structs.AddRange(_structs.Select(builder => builder.Build()));
+            Namespace.Structs
                 .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
                 .MatchSome(item => throw new SyntaxException(
                     "A struct defined under a namespace cannot have the access modifier " +
                     $"'{item.AccessModifier.ToSourceCode()}'."));
 
-            _namespace.Interfaces.AddRange(_interfaces.Select(builder => builder.Build()));
-            _namespace.Interfaces
+            Namespace.Interfaces.AddRange(_interfaces.Select(builder => builder.Build()));
+            Namespace.Interfaces
                 .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
                 .MatchSome(item => throw new SyntaxException(
                     "An interface defined under a namespace cannot have the access modifier " +
                     $"'{item.AccessModifier.ToSourceCode()}'."));
 
-            _namespace.Enums.AddRange(_enums.Select(builder => builder.Build()));
-            _namespace.Enums
+            Namespace.Enums.AddRange(_enums.Select(builder => builder.Build()));
+            Namespace.Enums
                 .FirstOrNone(item => !AllowedMemberAccessModifiers.Contains(item.AccessModifier))
                 .MatchSome(item => throw new SyntaxException(
                     "An enum defined under a namespace cannot have the access modifier " +
                     $"'{item.AccessModifier.ToSourceCode()}'."));
 
-            return _namespace;
+            return Namespace;
         }
     }
 }

--- a/src/SharpCode/NamespaceBuilder.cs
+++ b/src/SharpCode/NamespaceBuilder.cs
@@ -374,12 +374,18 @@ namespace SharpCode
                     .Any(x => x.Struct.Name.Exists(n => n.Equals(name, comparison)));
             }
 
+            if (memberType == MemberType.UsingStatement)
+            {
+                return Namespace.Usings.Any(x => x.Equals(name, comparison));
+            }
+
             if (!memberType.HasValue)
             {
                 return HasMember(name, MemberType.Class, accessModifier, comparison) ||
                     HasMember(name, MemberType.Enum, accessModifier, comparison) ||
                     HasMember(name, MemberType.Interface, accessModifier, comparison) ||
-                    HasMember(name, MemberType.Struct, accessModifier, comparison);
+                    HasMember(name, MemberType.Struct, accessModifier, comparison) ||
+                    HasMember(name, MemberType.UsingStatement, accessModifier, comparison);
             }
 
             return false;

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -35,4 +35,10 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+    <_Parameter1>SharpCode.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/SharpCode/StructBuilder.cs
+++ b/src/SharpCode/StructBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Optional;
@@ -11,7 +12,6 @@ namespace SharpCode
     /// </summary>
     public class StructBuilder
     {
-        private readonly Struct _struct = new Struct();
         private readonly List<ConstructorBuilder> _constructors = new List<ConstructorBuilder>();
         private readonly List<FieldBuilder> _fields = new List<FieldBuilder>();
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
@@ -22,9 +22,10 @@ namespace SharpCode
 
         internal StructBuilder(string name, AccessModifier accessModifier)
         {
-            _struct.Name = name;
-            _struct.AccessModifier = accessModifier;
+            Struct = new Struct(accessModifier, name: Option.Some(name));
         }
+
+        internal Struct Struct { get; private set; } = new Struct(AccessModifier.Public);
 
         /// <summary>
         /// Sets the access modifier of the struct.
@@ -34,7 +35,7 @@ namespace SharpCode
         /// </param>
         public StructBuilder WithAccessModifier(AccessModifier accessModifier)
         {
-            _struct.AccessModifier = accessModifier;
+            Struct = Struct.With(accessModifier: Option.Some(accessModifier));
             return this;
         }
 
@@ -44,9 +45,17 @@ namespace SharpCode
         /// <param name="name">
         /// The name of the struct.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithName(string name)
         {
-            _struct.Name = name;
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Struct = Struct.With(name: Option.Some(name));
             return this;
         }
 
@@ -56,9 +65,17 @@ namespace SharpCode
         /// <param name="summary">
         /// The content of the summary documentation.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="summary"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithSummary(string summary)
         {
-            _struct.Summary = Option.Some<string?>(summary);
+            if (summary is null)
+            {
+                throw new ArgumentNullException(nameof(summary));
+            }
+
+            Struct = Struct.With(summary: Option.Some(summary));
             return this;
         }
 
@@ -68,8 +85,16 @@ namespace SharpCode
         /// <param name="builder">
         /// The configuration of the constructor.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithConstructor(ConstructorBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _constructors.Add(builder);
             return this;
         }
@@ -80,8 +105,16 @@ namespace SharpCode
         /// <param name="builder">
         /// The configuration of the field.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithField(FieldBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _fields.Add(builder);
             return this;
         }
@@ -92,8 +125,24 @@ namespace SharpCode
         /// <param name="builders">
         /// A collection of fields.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithFields(IEnumerable<FieldBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _fields.AddRange(builders);
             return this;
         }
@@ -104,8 +153,16 @@ namespace SharpCode
         /// <param name="builders">
         /// A collection of fields.
         /// </param>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithFields(params FieldBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _fields.AddRange(builders);
             return this;
         }
@@ -116,8 +173,16 @@ namespace SharpCode
         /// <param name="builder">
         /// The configuration of the property.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithProperty(PropertyBuilder builder)
         {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             _properties.Add(builder);
             return this;
         }
@@ -128,8 +193,24 @@ namespace SharpCode
         /// <param name="builders">
         /// A collection of properties.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithProperties(IEnumerable<PropertyBuilder> builders)
         {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _properties.AddRange(builders);
             return this;
         }
@@ -140,8 +221,16 @@ namespace SharpCode
         /// <param name="builders">
         /// A collection of properties.
         /// </param>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithProperties(params PropertyBuilder[] builders)
         {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the builders is null.");
+            }
+
             _properties.AddRange(builders);
             return this;
         }
@@ -152,9 +241,17 @@ namespace SharpCode
         /// <param name="name">
         /// The name of the interface that the struct implements.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="name"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithImplementedInterface(string name)
         {
-            _struct.ImplementedInterfaces.Add(name);
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Struct.ImplementedInterfaces.Add(name);
             return this;
         }
 
@@ -164,9 +261,25 @@ namespace SharpCode
         /// <param name="names">
         /// A collection with the names of interfaces that the struct implements.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="names"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="names"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithImplementedInterfaces(IEnumerable<string> names)
         {
-            _struct.ImplementedInterfaces.AddRange(names);
+            if (names is null)
+            {
+                throw new ArgumentNullException(nameof(names));
+            }
+
+            if (names.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the names is null.");
+            }
+
+            Struct.ImplementedInterfaces.AddRange(names);
             return this;
         }
 
@@ -176,10 +289,63 @@ namespace SharpCode
         /// <param name="names">
         /// A collection with the names of interfaces that the struct implements.
         /// </param>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="names"/> is <c>null</c>.
+        /// </exception>
         public StructBuilder WithImplementedInterfaces(params string[] names)
         {
-            _struct.ImplementedInterfaces.AddRange(names);
+            if (names.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the names is null.");
+            }
+
+            Struct.ImplementedInterfaces.AddRange(names);
             return this;
+        }
+
+        /// <summary>
+        /// Checks whether the described member exists in the struct structure.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the member.
+        /// </param>
+        /// <param name="memberType">
+        /// The type of the member. By default all members will be taken into account.
+        /// </param>
+        /// <param name="accessModifier">
+        /// The access modifier of the member. By default all access modifiers will be taken into account.
+        /// </param>
+        /// <param name="comparison">
+        /// The comparision type to be performed when comparing the described name against the names of the actual
+        /// members. By default casing is ignored.
+        /// </param>
+        public bool HasMember(
+            string name,
+            MemberType? memberType = default,
+            AccessModifier? accessModifier = default,
+            StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            if (memberType == MemberType.Field)
+            {
+                return _fields
+                    .Where(x => !accessModifier.HasValue || x.Field.AccessModifier == accessModifier)
+                    .Any(x => x.Field.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (memberType == MemberType.Property)
+            {
+                return _properties
+                    .Where(x => !accessModifier.HasValue || x.Property.AccessModifier == accessModifier)
+                    .Any(x => x.Property.Name.Exists(n => n.Equals(name, comparison)));
+            }
+
+            if (!memberType.HasValue)
+            {
+                return HasMember(name, MemberType.Field, accessModifier, comparison) ||
+                    HasMember(name, MemberType.Property, accessModifier, comparison);
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -188,45 +354,58 @@ namespace SharpCode
         /// <param name="formatted">
         /// Indicates whether to format the source code.
         /// </param>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public string ToSourceCode(bool formatted = true) =>
             Build().ToSourceCode(formatted);
 
         /// <summary>
         /// Returns the source code of the built struct.
         /// </summary>
+        /// <exception cref="MissingBuilderSettingException">
+        /// A setting that is required to build a valid class structure is missing.
+        /// </exception>
+        /// <exception cref="SyntaxException">
+        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// </exception>
         public override string ToString() =>
             ToSourceCode();
 
         internal Struct Build()
         {
-            if (string.IsNullOrWhiteSpace(_struct.Name))
+            var structName = Struct.Name.ValueOr(string.Empty);
+            if (string.IsNullOrWhiteSpace(structName))
             {
                 throw new MissingBuilderSettingException(
                     "Providing the name of the struct is required when building a struct.");
             }
 
-            _struct.ImplementedInterfaces
+            Struct.ImplementedInterfaces
                 .FirstOrNone(x => string.IsNullOrWhiteSpace(x))
                 .MatchSome(_ => throw new MissingBuilderSettingException(
                     "Providing the name of the interface is required when adding an implemented interface to a struct."));
 
-            _struct.Fields.AddRange(_fields.Select(field => field.Build()));
-            _struct.Properties.AddRange(_properties.Select(prop => prop.Build()));
-            _struct.Properties
+            Struct.Fields.AddRange(_fields.Select(field => field.Build()));
+            Struct.Properties.AddRange(_properties.Select(prop => prop.Build()));
+            Struct.Properties
                 .FirstOrNone(x => x.DefaultValue.HasValue)
                 .MatchSome(prop => throw new SyntaxException(
                     "Default property values are not allowed in structs. (CS0573)"));
 
-            _struct.Constructors.AddRange(
+            Struct.Constructors.AddRange(
                 _constructors.Select(ctor => ctor
-                    .WithName(_struct.Name!)
+                    .WithName(structName)
                     .Build()));
-            _struct.Constructors
+            Struct.Constructors
                 .FirstOrNone(x => !x.Parameters.Any())
                 .MatchSome(ctor => throw new SyntaxException(
                     "Explicit parameterless contructors are not allowed in structs. (CS0568)"));
 
-            return _struct;
+            return Struct;
         }
   }
 }

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -19,147 +19,430 @@ namespace SharpCode
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 
-    internal class Field
+    /// <summary>
+    /// Represents the various types of C# structure members.
+    /// </summary>
+    public enum MemberType
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Private;
-
-        public bool IsReadonly { get; set; }
-
-        public string? Type { get; set; }
-
-        public string? Name { get; set; }
-
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        Interface,
+        Class,
+        Struct,
+        Enum,
+        EnumMember,
+        Field,
+        Property,
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 
-    internal class Property
+    internal readonly struct Field
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public Field(
+            AccessModifier accessModifier,
+            bool isReadonly = false,
+            Option<string> type = default,
+            Option<string> name = default,
+            Option<string> summary = default)
+        {
+            AccessModifier = accessModifier;
+            IsReadonly = isReadonly;
+            Type = type;
+            Name = name;
+            Summary = summary;
+        }
 
-        public bool IsStatic { get; set; } = false;
+        public readonly AccessModifier AccessModifier { get; }
 
-        public string? Type { get; set; }
+        public readonly bool IsReadonly { get; }
 
-        public string? Name { get; set; }
+        public readonly Option<string> Type { get; }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+        public readonly Option<string> Name { get; }
 
-        public Option<string> DefaultValue { get; set; } = Option.None<string>();
+        public readonly Option<string> Summary { get; }
 
-        public Option<string?> Getter { get; set; } = Option.Some<string?>(null);
-
-        public Option<string?> Setter { get; set; } = Option.Some<string?>(null);
+        public readonly Field With(
+            Option<AccessModifier> accessModifier = default,
+            Option<bool> isReadonly = default,
+            Option<string> type = default,
+            Option<string> name = default,
+            Option<string> summary = default) =>
+            new Field(
+                accessModifier.ValueOr(AccessModifier),
+                isReadonly.ValueOr(IsReadonly),
+                type.Else(Type),
+                name.Else(Name),
+                summary.Else(Summary));
     }
 
-    internal class Parameter
+    internal readonly struct Property
     {
-        public string? Type { get; set; }
+        public const string AutoGetterSetter = "@auto";
 
-        public string? Name { get; set; }
+        public Property(
+            AccessModifier accessModifier,
+            bool isStatic = false,
+            Option<string> type = default,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<string> defaultValue = default,
+            Option<string> getter = default,
+            Option<string> setter = default)
+        {
+            AccessModifier = accessModifier;
+            IsStatic = isStatic;
+            Type = type;
+            Name = name;
+            Summary = summary;
+            DefaultValue = defaultValue;
+            Getter = getter;
+            Setter = setter;
+        }
 
-        public string? ReceivingMember { get; set; }
+        public readonly AccessModifier AccessModifier { get; }
+
+        public readonly bool IsStatic { get; }
+
+        public readonly Option<string> Type { get; }
+
+        public readonly Option<string> Name { get; }
+
+        public readonly Option<string> Summary { get; }
+
+        public readonly Option<string> DefaultValue { get; }
+
+        public readonly Option<string> Getter { get; }
+
+        public readonly Option<string> Setter { get; }
+
+        public readonly Property With(
+            Option<AccessModifier> accessModifier = default,
+            Option<bool> isStatic = default,
+            Option<string> type = default,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<string> defaultValue = default,
+            Option<Option<string>> getter = default,
+            Option<Option<string>> setter = default) =>
+            new Property(
+                accessModifier: accessModifier.ValueOr(AccessModifier),
+                isStatic: isStatic.ValueOr(IsStatic),
+                type: type.Else(Type),
+                name: name.Else(Name),
+                summary: summary.Else(Summary),
+                defaultValue: defaultValue.Else(DefaultValue),
+                getter: getter.ValueOr(Getter),
+                setter: setter.ValueOr(Setter));
     }
 
-    internal class Constructor
+    internal readonly struct EnumerationMember
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public EnumerationMember(Option<string> name, Option<int> value = default, Option<string> summary = default)
+        {
+            Name = name;
+            Value = value;
+            Summary = summary;
+        }
 
-        public bool IsStatic { get; set; } = false;
+        public readonly Option<string> Name { get; }
 
-        public string? ClassName { get; set; }
+        public readonly Option<int> Value { get; }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+        public readonly Option<string> Summary { get; }
 
-        public List<Parameter> Parameters { get; } = new List<Parameter>();
-
-        public Option<IEnumerable<string>> BaseCallParameters { get; set; } = Option.None<IEnumerable<string>>();
+        public readonly EnumerationMember With(
+            Option<string> name = default,
+            Option<int> value = default,
+            Option<string> summary = default) =>
+            new EnumerationMember(
+                name: name.Else(Name),
+                value: value.Else(value),
+                summary: summary.Else(summary));
     }
 
-    internal class Class
+    internal readonly struct Parameter
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public Parameter(string type, string name, Option<string> receivingMember = default)
+        {
+            Type = type;
+            Name = name;
+            ReceivingMember = receivingMember;
+        }
 
-        public bool IsStatic { get; set; } = false;
+        public readonly string Type { get;  }
 
-        public string? Name { get; set; }
+        public readonly string Name { get;  }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
-
-        public Option<string> InheritedClass { get; set; } = Option.None<string>();
-
-        public List<string> ImplementedInterfaces { get; } = new List<string>();
-
-        public List<Field> Fields { get; } = new List<Field>();
-
-        public List<Property> Properties { get; } = new List<Property>();
-
-        public List<Constructor> Constructors { get; } = new List<Constructor>();
+        public readonly Option<string> ReceivingMember { get;  }
     }
 
-    internal class Struct
+    internal readonly struct Constructor
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public Constructor(
+            AccessModifier accessModifier,
+            bool isStatic = false,
+            Option<string> className = default,
+            Option<string> summary = default,
+            Option<List<Parameter>> parameters = default,
+            Option<IEnumerable<string>> baseCallParameters = default)
+        {
+            AccessModifier = accessModifier;
+            IsStatic = isStatic;
+            ClassName = className;
+            Summary = summary;
+            Parameters = parameters.ValueOr(new List<Parameter>());
+            BaseCallParameters = baseCallParameters;
+        }
 
-        public string? Name { get; set; }
+        public readonly AccessModifier AccessModifier { get; }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+        public readonly bool IsStatic { get; }
 
-        public List<string?> ImplementedInterfaces { get; } = new List<string?>();
+        public readonly Option<string> ClassName { get; }
 
-        public List<Constructor> Constructors { get; } = new List<Constructor>();
+        public readonly Option<string> Summary { get; }
 
-        public List<Field> Fields { get; } = new List<Field>();
+        public readonly List<Parameter> Parameters { get; }
 
-        public List<Property> Properties { get; } = new List<Property>();
+        public readonly Option<IEnumerable<string>> BaseCallParameters { get; }
+
+        public readonly Constructor With(
+            Option<AccessModifier> accessModifier = default,
+            Option<bool> isStatic = default,
+            Option<string> className = default,
+            Option<string> summary = default,
+            Option<IEnumerable<string>> baseCallParameters = default) =>
+            new Constructor(
+                accessModifier: accessModifier.ValueOr(AccessModifier),
+                isStatic: isStatic.ValueOr(IsStatic),
+                className: className.Else(ClassName),
+                summary: summary.Else(Summary),
+                parameters: Option.Some(Parameters),
+                baseCallParameters: baseCallParameters.Else(BaseCallParameters));
     }
 
-    internal class Interface
+    internal readonly struct Class
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public Class(
+            AccessModifier accessModifier,
+            bool isStatic = false,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<string> inheritedClass = default,
+            Option<List<string>> implementedInterfaces = default,
+            Option<List<Field>> fields = default,
+            Option<List<Property>> properties = default,
+            Option<List<Constructor>> constructors = default)
+        {
+            AccessModifier = accessModifier;
+            IsStatic = isStatic;
+            Name = name;
+            Summary = summary;
+            InheritedClass = inheritedClass;
+            ImplementedInterfaces = implementedInterfaces.ValueOr(new List<string>());
+            Fields = fields.ValueOr(new List<Field>());
+            Properties = properties.ValueOr(new List<Property>());
+            Constructors = constructors.ValueOr(new List<Constructor>());
+        }
 
-        public string? Name { get; set; }
+        public readonly AccessModifier AccessModifier { get; }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+        public readonly bool IsStatic { get; }
 
-        public List<string> ImplementedInterfaces { get; } = new List<string>();
+        public readonly Option<string> Name { get; }
 
-        public List<Property> Properties { get; } = new List<Property>();
+        public readonly Option<string> Summary { get; }
+
+        public readonly Option<string> InheritedClass { get; }
+
+        public readonly List<string> ImplementedInterfaces { get; }
+
+        public readonly List<Field> Fields { get; }
+
+        public readonly List<Property> Properties { get; }
+
+        public readonly List<Constructor> Constructors { get; }
+
+        public readonly Class With(
+            Option<AccessModifier> accessModifier = default,
+            Option<bool> isStatic = default,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<string> inheritedClass = default) =>
+            new Class(
+                accessModifier: accessModifier.ValueOr(AccessModifier),
+                isStatic: isStatic.ValueOr(IsStatic),
+                name: name.Else(Name),
+                summary: summary.Else(Summary),
+                inheritedClass: inheritedClass.Else(inheritedClass),
+                implementedInterfaces: Option.Some(ImplementedInterfaces),
+                fields: Option.Some(Fields),
+                properties: Option.Some(Properties),
+                constructors: Option.Some(Constructors));
     }
 
-    internal class EnumerationMember
+    internal readonly struct Struct
     {
-        public string? Name { get; set; }
+        public Struct(
+            AccessModifier accessModifier,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<List<string>> implementedInterfaces = default,
+            Option<List<Constructor>> constructors = default,
+            Option<List<Field>> fields = default,
+            Option<List<Property>> properties = default)
+        {
+            AccessModifier = accessModifier;
+            Name = name;
+            Summary = summary;
+            ImplementedInterfaces = implementedInterfaces.ValueOr(new List<string>());
+            Constructors = constructors.ValueOr(new List<Constructor>());
+            Fields = fields.ValueOr(new List<Field>());
+            Properties = properties.ValueOr(new List<Property>());
+        }
 
-        public Option<int> Value { get; set; } = Option.None<int>();
+        public readonly AccessModifier AccessModifier { get; }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+        public readonly Option<string> Name { get; }
+
+        public readonly Option<string> Summary { get; }
+
+        public readonly List<string> ImplementedInterfaces { get; }
+
+        public readonly List<Constructor> Constructors { get; }
+
+        public readonly List<Field> Fields { get; }
+
+        public readonly List<Property> Properties { get; }
+
+        public readonly Struct With(
+            Option<AccessModifier> accessModifier = default,
+            Option<string> name = default,
+            Option<string> summary = default) =>
+            new Struct(
+                accessModifier: accessModifier.ValueOr(AccessModifier),
+                name: name.Else(Name),
+                summary: summary.Else(Summary),
+                implementedInterfaces: Option.Some(ImplementedInterfaces),
+                constructors: Option.Some(Constructors),
+                fields: Option.Some(Fields),
+                properties: Option.Some(Properties));
     }
 
-    internal class Enumeration
+    internal readonly struct Interface
     {
-        public AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        public Interface(
+            AccessModifier accessModifier,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<List<string>> implementedInterfaces = default,
+            Option<List<Property>> properties = default)
+        {
+            AccessModifier = accessModifier;
+            Name = name;
+            Summary = summary;
+            ImplementedInterfaces = implementedInterfaces.ValueOr(new List<string>());
+            Properties = properties.ValueOr(new List<Property>());
+        }
 
-        public string? Name { get; set; }
+        public readonly AccessModifier AccessModifier { get; }
 
-        public Option<string?> Summary { get; set; } = Option.None<string?>();
+        public readonly Option<string> Name { get; }
 
-        public bool IsFlag { get; set; }
+        public readonly Option<string> Summary { get; }
 
-        public List<EnumerationMember> Members { get; } = new List<EnumerationMember>();
+        public readonly List<string> ImplementedInterfaces { get; }
+
+        public readonly List<Property> Properties { get; }
+
+        public Interface With(
+            Option<AccessModifier> accessModifier = default,
+            Option<string> name = default,
+            Option<string> summary = default) =>
+            new Interface(
+                accessModifier: accessModifier.ValueOr(AccessModifier),
+                name: name.Else(Name),
+                summary: summary.Else(Summary),
+                implementedInterfaces: Option.Some(ImplementedInterfaces),
+                properties: Option.Some(Properties));
     }
 
-    internal class Namespace
+    internal readonly struct Enumeration
     {
-        public string? Name { get; set; }
+        public Enumeration(
+            AccessModifier accessModifier,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<bool> isFlag = default,
+            Option<List<EnumerationMember>> members = default)
+        {
+            AccessModifier = accessModifier;
+            Name = name;
+            Summary = summary;
+            IsFlag = isFlag.ValueOr(false);
+            Members = members.ValueOr(new List<EnumerationMember>());
+        }
 
-        public List<string> Usings { get; } = new List<string>();
+        public readonly AccessModifier AccessModifier { get; }
 
-        public List<Class> Classes { get; } = new List<Class>();
+        public readonly Option<string> Name { get; }
 
-        public List<Struct> Structs { get; } = new List<Struct>();
+        public readonly Option<string> Summary { get; }
 
-        public List<Interface> Interfaces { get; } = new List<Interface>();
+        public readonly bool IsFlag { get; }
 
-        public List<Enumeration> Enums { get; } = new List<Enumeration>();
+        public readonly List<EnumerationMember> Members { get; }
+
+        public readonly Enumeration With(
+            Option<AccessModifier> accessModifier = default,
+            Option<string> name = default,
+            Option<string> summary = default,
+            Option<bool> isFlag = default) =>
+            new Enumeration(
+                accessModifier: accessModifier.ValueOr(AccessModifier),
+                name: name.Else(Name),
+                summary: summary.Else(Summary),
+                isFlag: isFlag.Else(Option.Some(IsFlag)),
+                members: Option.Some(Members));
+    }
+
+    internal readonly struct Namespace
+    {
+        public Namespace(
+            Option<string> name = default,
+            Option<List<string>> usings = default,
+            Option<List<Class>> classes = default,
+            Option<List<Struct>> structs = default,
+            Option<List<Interface>> interfaces = default,
+            Option<List<Enumeration>> enums = default)
+        {
+            Name = name;
+            Usings = usings.ValueOr(new List<string>());
+            Classes = classes.ValueOr(new List<Class>());
+            Structs = structs.ValueOr(new List<Struct>());
+            Interfaces = interfaces.ValueOr(new List<Interface>());
+            Enums = enums.ValueOr(new List<Enumeration>());
+        }
+
+        public readonly Option<string> Name { get; }
+
+        public readonly List<string> Usings { get; }
+
+        public readonly List<Class> Classes { get; }
+
+        public readonly List<Struct> Structs { get; }
+
+        public readonly List<Interface> Interfaces { get; }
+
+        public readonly List<Enumeration> Enums { get; }
+
+        public readonly Namespace With(Option<string> name = default) =>
+            new Namespace(
+                name: name.Else(Name),
+                usings: Option.Some(Usings),
+                classes: Option.Some(Classes),
+                structs: Option.Some(Structs),
+                interfaces: Option.Some(Interfaces),
+                enums: Option.Some(Enums));
     }
 }

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -32,6 +32,7 @@ namespace SharpCode
         EnumMember,
         Field,
         Property,
+        UsingStatement,
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 


### PR DESCRIPTION
This update adds an introspection API, allowing consumers to check whether a member has already been added to a specific structure, and introduces some major internal changes.

- internal structure definitions have been refactored
  - use `readonly struct` instead of `class`
  - use optionals instead of nullables
- sanitize nullable public arguments and throw appropriate exceptions
- make property auto getter/setter a bit less magical by using a `const string` identifier
- introduce introspection API via the `.HasMember()` method for applicable structures (namespace, interface, class, struct, enum)

## Introspection API

This is the first step to paving a way to a nice introspection API. For now there is the `.HasMember()` method which allows you to check with the builder (eg. `ClassBuilder`) of an applicable structure whether a member is already existing. Right now you can check the following builders for the following members:

- `NamespaceBuilder` -> interface, class, struct, enum, using statement
- `InterfaceBuilder` -> property
- `ClassBuilder` -> field, property
- `StructBuilder` -> field, property
- `EnumBuilder` -> enum member