### PR TITLE
Add support for generics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 6.x.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New access modifier - `AccessModifier.PrivateProtected` - `private protected`
+- Support for setting the access modifier of a property' getter and setter individually via the `PropertyBuilder.WithAccessModifier(AccessModifier getterAccessModifier, AccessModifier setterAccessModifier)` overloaded method
+- Support for defining type parameters when building classes, structs, interfaces, fields and parameters
+
+### Fixed
+
+- Removed the invalid access modifier `AccessModifier.PrivateInternal` - `private internal`
+
 ## [0.3.0] - 2021-08-05
 
 ### Added

--- a/src/SharpCode.Test/ClassBuilderTests.cs
+++ b/src/SharpCode.Test/ClassBuilderTests.cs
@@ -294,6 +294,86 @@ public static class Config
         }
 
         [Test]
+        public void CreateClass_WithTypeParameter_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .WithField(
+                    Code.CreateField("Dictionary", "_store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("TKey"),
+                            Code.CreateTypeParameter("TValue"))
+                        .MakeReadonly())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+    private readonly Dictionary<TKey, TValue> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .WithField(
+                    Code.CreateField("Dictionary", "_store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V"))
+                        .MakeReadonly())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<K, V>
+{
+    private readonly Dictionary<K, V> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_IEnumerable_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .WithField(
+                    Code.CreateField("Dictionary", "_store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V"))
+                        .MakeReadonly())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<K, V>
+{
+    private readonly Dictionary<K, V> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
         public void CreatingStaticClass_WithMultipleConstructors_Throws()
         {
             Assert.Throws<SyntaxException>(

--- a/src/SharpCode.Test/ClassBuilderTests.cs
+++ b/src/SharpCode.Test/ClassBuilderTests.cs
@@ -299,6 +299,65 @@ public static class Config
             var generatedCode = Code.CreateClass("Dict")
                 .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
                 .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_Params_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<K, V>
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_IEnumerable_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<K, V>
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_WithField_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
                 .WithField(
                     Code.CreateField("Dictionary", "_store")
                         .WithTypeParameters(
@@ -320,7 +379,7 @@ public class Dict<TKey, TValue>
         }
 
         [Test]
-        public void CreateClass_WithTypeParameters_Works()
+        public void CreateClass_WithTypeParameters_Params_WithField_Works()
         {
             var generatedCode = Code.CreateClass("Dict")
                 .WithTypeParameters(
@@ -346,7 +405,7 @@ public class Dict<K, V>
         }
 
         [Test]
-        public void CreateClass_WithTypeParameters_IEnumerable_Works()
+        public void CreateClass_WithTypeParameters_IEnumerable_WithField_Works()
         {
             var generatedCode = Code.CreateClass("Dict")
                 .WithTypeParameters(new List<TypeParameterBuilder>()
@@ -367,6 +426,95 @@ public class Dict<K, V>
 public class Dict<K, V>
 {
     private readonly Dictionary<K, V> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("TKey"),
+                            Code.CreateTypeParameter("TValue")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+    public Dictionary<TKey, TValue> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_Params_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<K, V>
+{
+    public Dictionary<K, V> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateClass_WithTypeParameters_IEnumerable_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateClass("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public class Dict<K, V>
+{
+    public Dictionary<K, V> Store
+    {
+        get;
+        set;
+    }
 }
             ".Trim().WithUnixEOL();
 

--- a/src/SharpCode.Test/FieldBuilderTests.cs
+++ b/src/SharpCode.Test/FieldBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -116,6 +117,49 @@ private protected readonly string _name;
         public void CreatingField_WithInvalidSummary_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => Code.CreateField().WithSummary(null));
+        }
+
+        [Test]
+        public void CreateField_WithTypeParameter_Works()
+        {
+            var generatedCode = Code.CreateField("Dictionary", "_store")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue"))
+                .ToSourceCode();
+
+            var expectedCode = "private Dictionary<TKey, TValue> _store;";
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateField_WithTypeParameters_Works()
+        {
+            var generatedCode = Code.CreateField("List", "_users", AccessModifier.Private)
+                .MakeReadonly()
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("User"))
+                .ToSourceCode();
+
+            var expectedCode = "private readonly List<User> _users;";
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateField_WithTypeParameters_IEnumerable_Works()
+        {
+            var generatedCode = Code.CreateField("Map", "_coordinates")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("string"),
+                    Code.CreateTypeParameter("(double X, double Y)"),
+                })
+                .ToSourceCode();
+
+            var expectedCode = "private Map<string, (double X, double Y)> _coordinates;";
+
+            Assert.AreEqual(expectedCode, generatedCode);
         }
 
         [Test]

--- a/src/SharpCode.Test/InterfaceBuilderTests.cs
+++ b/src/SharpCode.Test/InterfaceBuilderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -165,6 +166,154 @@ public interface ITest
 /// </summary>
 public interface ISerializable
 {
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateInterface_WithTypeParameter_Works()
+        {
+            var generatedCode = Code.CreateInterface("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateInterface_WithTypeParameters_Params_Works()
+        {
+            var generatedCode = Code.CreateInterface("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface Dict<K, V>
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateInterface_WithTypeParameters_IEnumerable_Works()
+        {
+            var generatedCode = Code.CreateInterface("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface Dict<K, V>
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateInterface_WithTypeParameters_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateInterface("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("TKey"),
+                            Code.CreateTypeParameter("TValue")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+    Dictionary<TKey, TValue> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateInterface_WithTypeParameters_Params_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateInterface("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface Dict<K, V>
+{
+    Dictionary<K, V> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateInterface_WithTypeParameters_IEnumerable_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateInterface("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public interface Dict<K, V>
+{
+    Dictionary<K, V> Store
+    {
+        get;
+        set;
+    }
 }
             ".Trim().WithUnixEOL();
 

--- a/src/SharpCode.Test/PropertyBuilderTests.cs
+++ b/src/SharpCode.Test/PropertyBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace SharpCode.Test
@@ -316,6 +317,68 @@ public static int Zero
         public void CreatingProperty_WithInvalidDefaultValue_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => Code.CreateProperty().WithDefaultValue(null));
+        }
+
+        [Test]
+        public void CreateProperty_WithTypeParameter_Works()
+        {
+            var generatedCode = Code.CreateProperty("Dictionary", "Store")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public Dictionary<TKey, TValue> Store
+{
+    get;
+    set;
+}"
+            .Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateProperty_WithTypeParameters_Works()
+        {
+            var generatedCode = Code.CreateProperty("List", "Users")
+                .WithTypeParameters(Code.CreateTypeParameter("User"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public List<User> Users
+{
+    get;
+    set;
+}"
+            .Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateProperty_WithTypeParameters_IEnumerable_Works()
+        {
+            var generatedCode = Code.CreateProperty("Map", "Coordinates")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("string"),
+                    Code.CreateTypeParameter("(double X, double Y)"),
+                })
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public Map<string, (double X, double Y)> Coordinates
+{
+    get;
+    set;
+}"
+            .Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
         }
 
         [Test]

--- a/src/SharpCode.Test/SharpCode.Test.csproj
+++ b/src/SharpCode.Test/SharpCode.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>
@@ -13,10 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.13.1.21947">
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0 " />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/SharpCode.Test/SharpCode.Test.csproj
+++ b/src/SharpCode.Test/SharpCode.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/SharpCode.Test/StructBuilderTests.cs
+++ b/src/SharpCode.Test/StructBuilderTests.cs
@@ -221,6 +221,234 @@ public struct Position
         }
 
         [Test]
+        public void CreateStruct_WithTypeParameter_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_Params_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<K, V>
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_IEnumerable_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<K, V>
+{
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_WithField_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .WithField(
+                    Code.CreateField("Dictionary", "_store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("TKey"),
+                            Code.CreateTypeParameter("TValue"))
+                        .MakeReadonly())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+    private readonly Dictionary<TKey, TValue> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_Params_WithField_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .WithField(
+                    Code.CreateField("Dictionary", "_store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V"))
+                        .MakeReadonly())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<K, V>
+{
+    private readonly Dictionary<K, V> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_IEnumerable_WithField_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .WithField(
+                    Code.CreateField("Dictionary", "_store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V"))
+                        .MakeReadonly())
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<K, V>
+{
+    private readonly Dictionary<K, V> _store;
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameter(Code.CreateTypeParameter("TKey", "IEquatable<TKey>"))
+                .WithTypeParameter(Code.CreateTypeParameter("TValue", TypeParameterConstraint.NotNull))
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("TKey"),
+                            Code.CreateTypeParameter("TValue")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<TKey, TValue>
+    where TKey : IEquatable<TKey> where TValue : notnull
+{
+    public Dictionary<TKey, TValue> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_Params_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameters(
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"))
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<K, V>
+{
+    public Dictionary<K, V> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
+        public void CreateStruct_WithTypeParameters_IEnumerable_WithProperty_Works()
+        {
+            var generatedCode = Code.CreateStruct("Dict")
+                .WithTypeParameters(new List<TypeParameterBuilder>()
+                {
+                    Code.CreateTypeParameter("K"),
+                    Code.CreateTypeParameter("V"),
+                })
+                .WithProperty(
+                    Code.CreateProperty("Dictionary", "Store")
+                        .WithTypeParameters(
+                            Code.CreateTypeParameter("K"),
+                            Code.CreateTypeParameter("V")))
+                .ToSourceCode()
+                .WithUnixEOL();
+
+            var expectedCode = @"
+public struct Dict<K, V>
+{
+    public Dictionary<K, V> Store
+    {
+        get;
+        set;
+    }
+}
+            ".Trim().WithUnixEOL();
+
+            Assert.AreEqual(expectedCode, generatedCode);
+        }
+
+        [Test]
         public void StructBuilder_ToSourceCode_ToString_Identical()
         {
             var toSourceCode = Code.CreateStruct()

--- a/src/SharpCode.Test/TypeParameterBuilderTests.cs
+++ b/src/SharpCode.Test/TypeParameterBuilderTests.cs
@@ -1,0 +1,28 @@
+using System;
+using NUnit.Framework;
+
+namespace SharpCode.Test;
+
+[TestFixture]
+public class TypeParameterBuilderTests
+{
+    [Test]
+    public void CreateTypeParameter_WithoutRequiredSettings_Throws()
+    {
+        Assert.Throws<MissingBuilderSettingException>(
+            () => Code.CreateTypeParameter().Build(),
+            "Generating the source code for a type parameter without setting the name should throw an exception.");
+
+        Assert.Throws<ArgumentNullException>(
+            () => Code.CreateTypeParameter().WithName(string.Empty).Build(),
+            "Generating the source code for a type parameter with an empty string as name should throw an exception.");
+
+        Assert.Throws<MissingBuilderSettingException>(
+            () => Code.CreateTypeParameter().WithName("  ").Build(),
+            "Generating the source code for a type parameter with whitespace name should throw an exception.");
+
+        Assert.Throws<ArgumentNullException>(
+            () => Code.CreateTypeParameter().WithName(null).Build(),
+            "Generating the source code for a type parameter with null as name should throw an exception.");
+    }
+}

--- a/src/SharpCode.Test/TypeParameterBuilderTests.cs
+++ b/src/SharpCode.Test/TypeParameterBuilderTests.cs
@@ -13,7 +13,7 @@ public class TypeParameterBuilderTests
             () => Code.CreateTypeParameter().Build(),
             "Generating the source code for a type parameter without setting the name should throw an exception.");
 
-        Assert.Throws<ArgumentNullException>(
+        Assert.Throws<MissingBuilderSettingException>(
             () => Code.CreateTypeParameter().WithName(string.Empty).Build(),
             "Generating the source code for a type parameter with an empty string as name should throw an exception.");
 

--- a/src/SharpCode/Ast.cs
+++ b/src/SharpCode/Ast.cs
@@ -471,6 +471,15 @@ namespace SharpCode
             return declaration;
         }
 
+        public static TypeParameterSyntax FromDefinition(TypeParameter definition) =>
+            SyntaxFactory.TypeParameter(SyntaxFactory.Identifier(definition.Name.ValueOrFailure()));
+
+        public static TypeParameterConstraintClauseSyntax GetTypeParameterConstraints(TypeParameter definition) =>
+            SyntaxFactory
+                .TypeParameterConstraintClause(SyntaxFactory.IdentifierName(definition.Name.ValueOrFailure()))
+                .WithConstraints(SyntaxFactory.SeparatedList<TypeParameterConstraintSyntax>(
+                    definition.Constraints.Select(constraint => SyntaxFactory.TypeConstraint(SyntaxFactory.IdentifierName(constraint)))));
+
         public static CompilationUnitSyntax NamespaceContainer(List<string> usings) =>
             SyntaxFactory.CompilationUnit().WithUsings(
                 SyntaxFactory.List(

--- a/src/SharpCode/Ast.cs
+++ b/src/SharpCode/Ast.cs
@@ -476,6 +476,20 @@ namespace SharpCode
                 declaration = declaration.WithLeadingTrivia(CreateXmlDoc(summary));
             });
 
+            if (definition.TypeParameters.Any())
+            {
+                declaration = declaration
+                    .WithTypeParameterList(
+                        SyntaxFactory.TypeParameterList(
+                            SyntaxFactory.SeparatedList(
+                                definition.TypeParameters.Select(FromDefinition))))
+                    .WithConstraintClauses(
+                        SyntaxFactory.List(
+                            definition.TypeParameters
+                                .Where(x => x.Constraints.Any())
+                                .Select(GetTypeParameterConstraints)));
+            }
+
             if (definition.ImplementedInterfaces.Any())
             {
                 declaration = declaration.AddBaseListTypes(

--- a/src/SharpCode/Ast.cs
+++ b/src/SharpCode/Ast.cs
@@ -375,6 +375,20 @@ namespace SharpCode
                 declaration = declaration.WithLeadingTrivia(CreateXmlDoc(summary));
             });
 
+            if (definition.TypeParameters.Any())
+            {
+                declaration = declaration
+                    .WithTypeParameterList(
+                        SyntaxFactory.TypeParameterList(
+                            SyntaxFactory.SeparatedList(
+                                definition.TypeParameters.Select(FromDefinition))))
+                    .WithConstraintClauses(
+                        SyntaxFactory.List(
+                            definition.TypeParameters
+                                .Where(x => x.Constraints.Any())
+                                .Select(GetTypeParameterConstraints)));
+            }
+
             if (definition.ImplementedInterfaces.Any())
             {
                 declaration = declaration.AddBaseListTypes(

--- a/src/SharpCode/Ast.cs
+++ b/src/SharpCode/Ast.cs
@@ -312,6 +312,20 @@ namespace SharpCode
                         SyntaxFactory.ParseTypeName(name)));
             });
 
+            if (definition.TypeParameters.Any())
+            {
+                declaration = declaration
+                    .WithTypeParameterList(
+                        SyntaxFactory.TypeParameterList(
+                            SyntaxFactory.SeparatedList(
+                                definition.TypeParameters.Select(FromDefinition))))
+                    .WithConstraintClauses(
+                        SyntaxFactory.List(
+                            definition.TypeParameters
+                                .Where(x => x.Constraints.Any())
+                                .Select(GetTypeParameterConstraints)));
+            }
+
             if (definition.ImplementedInterfaces.Any())
             {
                 declaration = declaration.AddBaseListTypes(

--- a/src/SharpCode/Ast.cs
+++ b/src/SharpCode/Ast.cs
@@ -71,7 +71,16 @@ namespace SharpCode
         {
             var declaration = SyntaxFactory
                 .PropertyDeclaration(
-                    type: SyntaxFactory.ParseTypeName(definition.Type.ValueOrFailure()),
+                    type: definition.TypeParameters.Any()
+                        /* create property declaration with type parameters, ie. "Dictionary<TKey, TValue> Store" */
+                        ? SyntaxFactory.GenericName(definition.Type.ValueOrFailure())
+                            .WithTypeArgumentList(
+                                SyntaxFactory.TypeArgumentList(
+                                    SyntaxFactory.SeparatedList(
+                                        definition.TypeParameters.Select<TypeParameter, TypeSyntax>(
+                                            typeParam => SyntaxFactory.IdentifierName(typeParam.Name.ValueOrFailure())))))
+                        /* create regular property declaration, ie. "string Name" */
+                        : SyntaxFactory.ParseTypeName(definition.Type.ValueOrFailure()),
                     identifier: definition.Name.ValueOrFailure())
                 .AddModifiers(FromDefinition(definition.AccessModifier));
 

--- a/src/SharpCode/Ast.cs
+++ b/src/SharpCode/Ast.cs
@@ -34,9 +34,21 @@ namespace SharpCode
 
         public static FieldDeclarationSyntax FromDefinition(Field definition)
         {
-            var variableDeclaration = SyntaxFactory
-                .VariableDeclaration(SyntaxFactory.ParseTypeName(definition.Type.ValueOrFailure()))
-                .AddVariables(SyntaxFactory.VariableDeclarator(definition.Name.ValueOrFailure()));
+            var variableDeclaration = definition.TypeParameters.Any()
+                /* create variable declaration with type parameters, ie. "Dictionary<TKey, TValue> _store" */
+                ? SyntaxFactory
+                    .VariableDeclaration(
+                        SyntaxFactory.GenericName(definition.Type.ValueOrFailure())
+                            .WithTypeArgumentList(
+                                SyntaxFactory.TypeArgumentList(
+                                    SyntaxFactory.SeparatedList(
+                                        definition.TypeParameters.Select<TypeParameter, TypeSyntax>(
+                                            typeParam => SyntaxFactory.IdentifierName(typeParam.Name.ValueOrFailure()))))))
+                    .AddVariables(SyntaxFactory.VariableDeclarator(definition.Name.ValueOrFailure()))
+                /* create regular variable declaration, ie. "string _name" */
+                : SyntaxFactory
+                    .VariableDeclaration(SyntaxFactory.ParseTypeName(definition.Type.ValueOrFailure()))
+                    .AddVariables(SyntaxFactory.VariableDeclarator(definition.Name.ValueOrFailure()));
 
             var fieldDeclaration = SyntaxFactory
                 .FieldDeclaration(variableDeclaration)

--- a/src/SharpCode/ClassBuilder.cs
+++ b/src/SharpCode/ClassBuilder.cs
@@ -15,6 +15,7 @@ namespace SharpCode
         private readonly List<FieldBuilder> _fields = new List<FieldBuilder>();
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
         private readonly List<ConstructorBuilder> _constructors = new List<ConstructorBuilder>();
+        private readonly List<TypeParameterBuilder> _typeParameters = new ();
 
         internal ClassBuilder()
         {
@@ -106,6 +107,65 @@ namespace SharpCode
             }
 
             Class = Class.With(summary: Option.Some(summary));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a type parameter to the class being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        public ClassBuilder WithTypeParameter(TypeParameterBuilder builder)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            _typeParameters.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the class being built.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public ClassBuilder WithTypeParameters(params TypeParameterBuilder[] builders)
+        {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the class being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public ClassBuilder WithTypeParameters(IEnumerable<TypeParameterBuilder> builders)
+        {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
             return this;
         }
 
@@ -320,6 +380,7 @@ namespace SharpCode
                     .WithName(Class.Name.ValueOrFailure())
                     .MakeStatic(Class.IsStatic)
                     .Build()));
+            Class.TypeParameters.AddRange(_typeParameters.Select(builder => builder.Build()));
 
             return Class;
         }

--- a/src/SharpCode/Code.cs
+++ b/src/SharpCode/Code.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Optional;
 
 namespace SharpCode
@@ -393,5 +394,17 @@ namespace SharpCode
 
             return new PropertyBuilder(accessModifier, setterAccessModifier, type, name);
         }
+
+        public static TypeParameterBuilder CreateTypeParameter() =>
+            new TypeParameterBuilder();
+
+        public static TypeParameterBuilder CreateTypeParameter(string name) =>
+            new TypeParameterBuilder(name);
+
+        public static TypeParameterBuilder CreateTypeParameter(string name, params string[] constraints) =>
+            new TypeParameterBuilder(name, Option.Some<IEnumerable<string>>(constraints));
+
+        public static TypeParameterBuilder CreateTypeParameter(string name, IEnumerable<string> constraints) =>
+            new TypeParameterBuilder(name, Option.Some(constraints));
     }
 }

--- a/src/SharpCode/Code.cs
+++ b/src/SharpCode/Code.cs
@@ -395,15 +395,38 @@ namespace SharpCode
             return new PropertyBuilder(accessModifier, setterAccessModifier, type, name);
         }
 
+        /// <summary>
+        /// Creates a new <see cref="TypeParameterBuilder"/> instance for building type parameters.
+        /// </summary>
         public static TypeParameterBuilder CreateTypeParameter() =>
             new TypeParameterBuilder();
 
+        /// <summary>
+        /// Creates a new pre-configured <see cref="TypeParameterBuilder"/> instance for building type parameters.
+        /// Configures the <see cref="TypeParameterBuilder"/> instance with the
+        /// specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The name of the type parameter.</param>
         public static TypeParameterBuilder CreateTypeParameter(string name) =>
             new TypeParameterBuilder(name);
 
+        /// <summary>
+        /// Creates a new pre-configured <see cref="TypeParameterBuilder"/> instance for building type parameters.
+        /// Configures the <see cref="TypeParameterBuilder"/> instance with the
+        /// specified <paramref name="name"/> and <paramref name="constraints"/>.
+        /// </summary>
+        /// <param name="name">The name of the type parameter.</param>
+        /// <param name="constraints">The constraints of the type parameter.</param>
         public static TypeParameterBuilder CreateTypeParameter(string name, params string[] constraints) =>
             new TypeParameterBuilder(name, Option.Some<IEnumerable<string>>(constraints));
 
+        /// <summary>
+        /// Creates a new pre-configured <see cref="TypeParameterBuilder"/> instance for building type parameters.
+        /// Configures the <see cref="TypeParameterBuilder"/> instance with the
+        /// specified <paramref name="name"/> and <paramref name="constraints"/>.
+        /// </summary>
+        /// <param name="name">The name of the type parameter.</param>
+        /// <param name="constraints">The constraints of the type parameter.</param>
         public static TypeParameterBuilder CreateTypeParameter(string name, IEnumerable<string> constraints) =>
             new TypeParameterBuilder(name, Option.Some(constraints));
     }

--- a/src/SharpCode/FieldBuilder.cs
+++ b/src/SharpCode/FieldBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Optional;
 using Optional.Unsafe;
 
@@ -9,6 +11,8 @@ namespace SharpCode
     /// </summary>
     public class FieldBuilder
     {
+        private readonly List<TypeParameterBuilder> _typeParameters = new List<TypeParameterBuilder>();
+
         internal FieldBuilder()
         {
         }
@@ -121,6 +125,65 @@ namespace SharpCode
         }
 
         /// <summary>
+        /// Adds a type parameter to the field being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        public FieldBuilder WithTypeParameter(TypeParameterBuilder builder)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            _typeParameters.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the field being built.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public FieldBuilder WithTypeParameters(params TypeParameterBuilder[] builders)
+        {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the field being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public FieldBuilder WithTypeParameters(IEnumerable<TypeParameterBuilder> builders)
+        {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
         /// Returns the source code of the built field.
         /// </summary>
         /// <exception cref="MissingBuilderSettingException">
@@ -156,6 +219,8 @@ namespace SharpCode
                 throw new MissingBuilderSettingException(
                     "Providing the name of the field is required when building a field.");
             }
+
+            Field.TypeParameters.AddRange(_typeParameters.Select(builder => builder.Build()));
 
             return Field;
         }

--- a/src/SharpCode/FieldBuilder.cs
+++ b/src/SharpCode/FieldBuilder.cs
@@ -124,10 +124,10 @@ namespace SharpCode
         /// Returns the source code of the built field.
         /// </summary>
         /// <exception cref="MissingBuilderSettingException">
-        /// A setting that is required to build a valid class structure is missing.
+        /// A setting that is required to build a valid field structure is missing.
         /// </exception>
         /// <exception cref="SyntaxException">
-        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// The field builder is configured in such a way that the resulting code would be invalid.
         /// </exception>
         public string ToSourceCode() =>
             Ast.Stringify(Ast.FromDefinition(Build()));
@@ -136,10 +136,10 @@ namespace SharpCode
         /// Returns the source code of the built field.
         /// </summary>
         /// <exception cref="MissingBuilderSettingException">
-        /// A setting that is required to build a valid class structure is missing.
+        /// A setting that is required to build a valid field structure is missing.
         /// </exception>
         /// <exception cref="SyntaxException">
-        /// The class builder is configured in such a way that the resulting code would be invalid.
+        /// The field builder is configured in such a way that the resulting code would be invalid.
         /// </exception>
         public override string ToString() =>
             ToSourceCode();

--- a/src/SharpCode/InterfaceBuilder.cs
+++ b/src/SharpCode/InterfaceBuilder.cs
@@ -12,6 +12,7 @@ namespace SharpCode
     public class InterfaceBuilder
     {
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
+        private readonly List<TypeParameterBuilder> _typeParameters = new List<TypeParameterBuilder>();
 
         internal InterfaceBuilder()
         {
@@ -158,6 +159,65 @@ namespace SharpCode
         }
 
         /// <summary>
+        /// Adds a type parameter to the interface being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        public InterfaceBuilder WithTypeParameter(TypeParameterBuilder builder)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            _typeParameters.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the interface being built.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public InterfaceBuilder WithTypeParameters(params TypeParameterBuilder[] builders)
+        {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the interface being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public InterfaceBuilder WithTypeParameters(IEnumerable<TypeParameterBuilder> builders)
+        {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
         /// Checks whether the described member exists in the interface structure.
         /// </summary>
         /// <param name="name">
@@ -240,6 +300,8 @@ namespace SharpCode
             {
                 throw new SyntaxException("Interface properties can only define an auto implemented setter.");
             }
+
+            Interface.TypeParameters.AddRange(_typeParameters.Select(builder => builder.Build()));
 
             return Interface;
         }

--- a/src/SharpCode/PropertyBuilder.cs
+++ b/src/SharpCode/PropertyBuilder.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Optional;
 using Optional.Unsafe;
 
@@ -10,6 +12,8 @@ namespace SharpCode
     /// </summary>
     public class PropertyBuilder
     {
+        private readonly List<TypeParameterBuilder> _typeParameters = new List<TypeParameterBuilder>();
+
         internal PropertyBuilder()
         {
         }
@@ -290,6 +294,65 @@ namespace SharpCode
         }
 
         /// <summary>
+        /// Adds a type parameter to the property being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        public PropertyBuilder WithTypeParameter(TypeParameterBuilder builder)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            _typeParameters.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the property being built.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public PropertyBuilder WithTypeParameters(params TypeParameterBuilder[] builders)
+        {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the property being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public PropertyBuilder WithTypeParameters(IEnumerable<TypeParameterBuilder> builders)
+        {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
         /// Returns the source code of the built property.
         /// </summary>
         /// <exception cref="MissingBuilderSettingException">
@@ -346,6 +409,8 @@ namespace SharpCode
                     throw new SyntaxException("Only auto implemented properties can have a default value. (CS8050)");
                 }
             }
+
+            Property.TypeParameters.AddRange(_typeParameters.Select(builder => builder.Build()));
 
             return Property;
         }

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>Enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\SharpCode.ruleset</CodeAnalysisRuleSet>

--- a/src/SharpCode/SharpCode.csproj
+++ b/src/SharpCode/SharpCode.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.13.1.21947">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/SharpCode/StructBuilder.cs
+++ b/src/SharpCode/StructBuilder.cs
@@ -15,6 +15,7 @@ namespace SharpCode
         private readonly List<ConstructorBuilder> _constructors = new List<ConstructorBuilder>();
         private readonly List<FieldBuilder> _fields = new List<FieldBuilder>();
         private readonly List<PropertyBuilder> _properties = new List<PropertyBuilder>();
+        private readonly List<TypeParameterBuilder> _typeParameters = new List<TypeParameterBuilder>();
 
         internal StructBuilder()
         {
@@ -304,6 +305,65 @@ namespace SharpCode
         }
 
         /// <summary>
+        /// Adds a type parameter to the struct being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        public StructBuilder WithTypeParameter(TypeParameterBuilder builder)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            _typeParameters.Add(builder);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the struct being built.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public StructBuilder WithTypeParameters(params TypeParameterBuilder[] builders)
+        {
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bunch of type parameters to the struct being built.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of the specified <paramref name="builders"/> is <c>null</c>.
+        /// </exception>
+        public StructBuilder WithTypeParameters(IEnumerable<TypeParameterBuilder> builders)
+        {
+            if (builders is null)
+            {
+                throw new ArgumentNullException(nameof(builders));
+            }
+
+            if (builders.Any(x => x is null))
+            {
+                throw new ArgumentException("One of the type parameter builders is null.");
+            }
+
+            _typeParameters.AddRange(builders);
+            return this;
+        }
+
+        /// <summary>
         /// Checks whether the described member exists in the struct structure.
         /// </summary>
         /// <param name="name">
@@ -401,6 +461,8 @@ namespace SharpCode
                 .FirstOrNone(x => !x.Parameters.Any())
                 .MatchSome(ctor => throw new SyntaxException(
                     "Explicit parameterless contructors are not allowed in structs. (CS0568)"));
+
+            Struct.TypeParameters.AddRange(_typeParameters.Select(builder => builder.Build()));
 
             return Struct;
         }

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -111,7 +111,8 @@ namespace SharpCode
             Option<string> summary = default,
             Option<string> defaultValue = default,
             Option<string> getter = default,
-            Option<string> setter = default)
+            Option<string> setter = default,
+            Option<List<TypeParameter>> typeParameters = default)
         {
             AccessModifier = accessModifier;
             SetterAccessModifier = setterAccessModifier;
@@ -122,6 +123,7 @@ namespace SharpCode
             DefaultValue = defaultValue;
             Getter = getter;
             Setter = setter;
+            TypeParameters = typeParameters.ValueOr(new List<TypeParameter>());
         }
 
         public readonly AccessModifier AccessModifier { get; }
@@ -141,6 +143,8 @@ namespace SharpCode
         public readonly Option<string> Getter { get; }
 
         public readonly Option<string> Setter { get; }
+
+        public readonly List<TypeParameter> TypeParameters { get; }
 
         public readonly Property With(
             Option<AccessModifier> accessModifier = default,

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -373,13 +373,15 @@ namespace SharpCode
             Option<string> name = default,
             Option<string> summary = default,
             Option<List<string>> implementedInterfaces = default,
-            Option<List<Property>> properties = default)
+            Option<List<Property>> properties = default,
+            Option<List<TypeParameter>> typeParameters = default)
         {
             AccessModifier = accessModifier;
             Name = name;
             Summary = summary;
             ImplementedInterfaces = implementedInterfaces.ValueOr(new List<string>());
             Properties = properties.ValueOr(new List<Property>());
+            TypeParameters = typeParameters.ValueOr(new List<TypeParameter>());
         }
 
         public readonly AccessModifier AccessModifier { get; }
@@ -391,6 +393,8 @@ namespace SharpCode
         public readonly List<string> ImplementedInterfaces { get; }
 
         public readonly List<Property> Properties { get; }
+
+        public readonly List<TypeParameter> TypeParameters { get; }
 
         public Interface With(
             Option<AccessModifier> accessModifier = default,

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -261,7 +261,8 @@ namespace SharpCode
             Option<List<string>> implementedInterfaces = default,
             Option<List<Field>> fields = default,
             Option<List<Property>> properties = default,
-            Option<List<Constructor>> constructors = default)
+            Option<List<Constructor>> constructors = default,
+            Option<List<TypeParameter>> typeParameters = default)
         {
             AccessModifier = accessModifier;
             IsStatic = isStatic;
@@ -272,6 +273,7 @@ namespace SharpCode
             Fields = fields.ValueOr(new List<Field>());
             Properties = properties.ValueOr(new List<Property>());
             Constructors = constructors.ValueOr(new List<Constructor>());
+            TypeParameters = typeParameters.ValueOr(new List<TypeParameter>());
         }
 
         public readonly AccessModifier AccessModifier { get; }
@@ -291,6 +293,8 @@ namespace SharpCode
         public readonly List<Property> Properties { get; }
 
         public readonly List<Constructor> Constructors { get; }
+
+        public readonly List<TypeParameter> TypeParameters { get; }
 
         public readonly Class With(
             Option<AccessModifier> accessModifier = default,

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -36,6 +36,24 @@ namespace SharpCode
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 
+    internal readonly struct TypeParameter
+    {
+        public TypeParameter(Option<string> name = default, Option<List<string>> constraints = default)
+        {
+            Name = name;
+            Constraints = constraints.ValueOr(new List<string>());
+        }
+
+        public readonly Option<string> Name { get; }
+
+        public readonly List<string> Constraints { get; }
+
+        public TypeParameter With(Option<string> name) =>
+            new TypeParameter(
+                name: name.Else(Name),
+                constraints: Option.Some(Constraints));
+    }
+
     internal readonly struct Field
     {
         public Field(

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -61,13 +61,15 @@ namespace SharpCode
             bool isReadonly = false,
             Option<string> type = default,
             Option<string> name = default,
-            Option<string> summary = default)
+            Option<string> summary = default,
+            Option<List<TypeParameter>> typeParameters = default)
         {
             AccessModifier = accessModifier;
             IsReadonly = isReadonly;
             Type = type;
             Name = name;
             Summary = summary;
+            TypeParameters = typeParameters.ValueOr(new List<TypeParameter>());
         }
 
         public readonly AccessModifier AccessModifier { get; }
@@ -79,6 +81,8 @@ namespace SharpCode
         public readonly Option<string> Name { get; }
 
         public readonly Option<string> Summary { get; }
+
+        public readonly List<TypeParameter> TypeParameters { get; }
 
         public readonly Field With(
             Option<AccessModifier> accessModifier = default,

--- a/src/SharpCode/Structures.cs
+++ b/src/SharpCode/Structures.cs
@@ -327,7 +327,8 @@ namespace SharpCode
             Option<List<string>> implementedInterfaces = default,
             Option<List<Constructor>> constructors = default,
             Option<List<Field>> fields = default,
-            Option<List<Property>> properties = default)
+            Option<List<Property>> properties = default,
+            Option<List<TypeParameter>> typeParameters = default)
         {
             AccessModifier = accessModifier;
             Name = name;
@@ -336,6 +337,7 @@ namespace SharpCode
             Constructors = constructors.ValueOr(new List<Constructor>());
             Fields = fields.ValueOr(new List<Field>());
             Properties = properties.ValueOr(new List<Property>());
+            TypeParameters = typeParameters.ValueOr(new List<TypeParameter>());
         }
 
         public readonly AccessModifier AccessModifier { get; }
@@ -351,6 +353,8 @@ namespace SharpCode
         public readonly List<Field> Fields { get; }
 
         public readonly List<Property> Properties { get; }
+
+        public readonly List<TypeParameter> TypeParameters { get; }
 
         public readonly Struct With(
             Option<AccessModifier> accessModifier = default,

--- a/src/SharpCode/TypeParameterBuilder.cs
+++ b/src/SharpCode/TypeParameterBuilder.cs
@@ -6,22 +6,33 @@ using Optional.Unsafe;
 
 namespace SharpCode;
 
+/// <summary>
+/// Provides functionalty for building type parameters.
+/// <see cref="TypeParameterBuilder"/> instances are <b>not</b> immutable.
+/// </summary>
 public class TypeParameterBuilder
 {
-    public TypeParameterBuilder()
+    internal TypeParameterBuilder()
     {
     }
 
-    public TypeParameterBuilder(string name, Option<IEnumerable<string>> constraints = default)
+    internal TypeParameterBuilder(string name, Option<IEnumerable<string>> constraints = default)
     {
         TypeParameter = new TypeParameter(name: Option.Some(name), constraints.Map(x => x.ToList()));
     }
 
     internal TypeParameter TypeParameter { get; private set; } = new TypeParameter(name: Option.None<string>());
 
+    /// <summary>
+    /// Sets the name of the type parameter.
+    /// </summary>
+    /// <param name="name">The name of the type parameter.</param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="name"/> is <c>null</c>.
+    /// </exception>
     public TypeParameterBuilder WithName(string name)
     {
-        if (string.IsNullOrEmpty(name))
+        if (name is null)
         {
             throw new ArgumentNullException(nameof(name));
         }
@@ -30,9 +41,20 @@ public class TypeParameterBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds a constraint to the the type parameter. See <see cref="TypeParameterConstraint"/>
+    /// for various constraints and their explanations.
+    /// </summary>
+    /// <param name="constraint">
+    /// The constraint to be added to the type parameter.
+    /// Optionally, you can use <see cref="TypeParameterConstraint"/> members.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specific <paramref name="constraint"/> is <c>null</c>.
+    /// </exception>
     public TypeParameterBuilder WithConstraint(string constraint)
     {
-        if (string.IsNullOrWhiteSpace(constraint))
+        if (constraint is null)
         {
             throw new ArgumentNullException(nameof(constraint));
         }
@@ -41,6 +63,18 @@ public class TypeParameterBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds a bunch of constraints to the type parameter. See <see cref="TypeParameterConstraint"/>
+    /// for various constraints and their explanations.
+    /// </summary>
+    /// <param name="constraints">
+    /// The constraints to be added to the type parameter.
+    /// Optionally, you can use <see cref="TypeParameterConstraint"/> members.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// One of the specified <paramref name="constraints"/> is <c>null</c> or
+    /// an empty (invalid) string.
+    /// </exception>
     public TypeParameterBuilder WithConstraints(params string[] constraints)
     {
         if (constraints.Any(string.IsNullOrWhiteSpace))
@@ -52,6 +86,21 @@ public class TypeParameterBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds a bunch of constraints to the type parameter. See <see cref="TypeParameterConstraint"/>
+    /// for various constraints and their explanations.
+    /// </summary>
+    /// <param name="constraints">
+    /// The constraints to be added to the type parameter.
+    /// Optionally, you can use <see cref="TypeParameterConstraint"/> members.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="constraints"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// One of the specified <paramref name="constraints"/> is <c>null</c> or
+    /// an empty (invalid) string.
+    /// </exception>
     public TypeParameterBuilder WithConstraints(IEnumerable<string> constraints)
     {
         if (constraints is null)

--- a/src/SharpCode/TypeParameterBuilder.cs
+++ b/src/SharpCode/TypeParameterBuilder.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Optional;
+using Optional.Unsafe;
+
+namespace SharpCode;
+
+public class TypeParameterBuilder
+{
+    public TypeParameterBuilder()
+    {
+    }
+
+    public TypeParameterBuilder(string name, Option<IEnumerable<string>> constraints = default)
+    {
+        TypeParameter = new TypeParameter(name: Option.Some(name), constraints.Map(x => x.ToList()));
+    }
+
+    internal TypeParameter TypeParameter { get; private set; } = new TypeParameter(name: Option.None<string>());
+
+    public TypeParameterBuilder WithName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        TypeParameter = TypeParameter.With(name: Option.Some(name));
+        return this;
+    }
+
+    public TypeParameterBuilder WithConstraint(string constraint)
+    {
+        if (string.IsNullOrWhiteSpace(constraint))
+        {
+            throw new ArgumentNullException(nameof(constraint));
+        }
+
+        TypeParameter.Constraints.Add(constraint);
+        return this;
+    }
+
+    public TypeParameterBuilder WithConstraints(params string[] constraints)
+    {
+        if (constraints.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("One of the constraints value is null or empty.");
+        }
+
+        TypeParameter.Constraints.AddRange(constraints);
+        return this;
+    }
+
+    public TypeParameterBuilder WithConstraints(IEnumerable<string> constraints)
+    {
+        if (constraints is null)
+        {
+            throw new ArgumentNullException(nameof(constraints));
+        }
+
+        if (constraints.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("One of the constraints value is null or empty.");
+        }
+
+        TypeParameter.Constraints.AddRange(constraints);
+        return this;
+    }
+
+    internal TypeParameter Build()
+    {
+        if (string.IsNullOrWhiteSpace(TypeParameter.Name.ValueOrDefault()))
+        {
+            throw new MissingBuilderSettingException(
+                "Providing the name of the type parameter is required when building a type parameter.");
+        }
+
+        return TypeParameter;
+    }
+}
+
+/// <summary>
+/// For more information about type paramater constraints, see the official documentation
+/// https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters .
+/// </summary>
+public static class TypeParameterConstraint
+{
+    /// <summary>
+    /// The type argument must be a non-nullable value type.
+    /// For information about nullable value types, see Nullable value types.
+    /// Because all value types have an accessible parameterless constructor,
+    /// the struct constraint implies the new() constraint and can't be combined
+    /// with the new() constraint. You can't combine the struct constraint with
+    /// the unmanaged constraint.
+    /// </summary>
+    public const string Struct = "struct";
+
+    /// <summary>
+    /// The type argument must be a reference type. This constraint applies also
+    /// to any class, interface, delegate, or array type. In a nullable context
+    /// in C# 8.0 or later, T must be a non-nullable reference type.
+    /// </summary>
+    public const string Class = "class";
+
+    /// <summary>
+    /// The type argument must be a reference type, either nullable or
+    /// non-nullable. This constraint applies also to any class, interface,
+    /// delegate, or array type.
+    /// </summary>
+    public const string NullableClass = "class?";
+
+    /// <summary>
+    /// The type argument must be a non-nullable type. The argument can be a
+    /// non-nullable reference type in C# 8.0 or later, or a non-nullable value
+    /// type.
+    /// </summary>
+    public const string NotNull = "notnull";
+
+    /// <summary>
+    /// This constraint resolves the ambiguity when you need to specify an
+    /// unconstrained type parameter when you override a method or provide an
+    /// explicit interface implementation. The default constraint implies the
+    /// base method without either the class or struct constraint.
+    /// For more information, see the default constraint spec proposal.
+    /// </summary>
+    public const string Default = "default";
+
+    /// <summary>
+    /// The type argument must be a non-nullable unmanaged type. The unmanaged
+    /// constraint implies the struct constraint and can't be combined with
+    /// either the struct or new() constraints.
+    /// </summary>
+    public const string Unmanaged = "unmanaged";
+
+    /// <summary>
+    /// The type argument must have a public parameterless constructor. When
+    /// used together with other constraints, the new() constraint must be
+    /// specified last. The new() constraint can't be combined with the struct
+    /// and unmanaged constraints.
+    /// </summary>
+    public const string New = "new()";
+}


### PR DESCRIPTION
This update will add support for generics when generating code for classes, structs, fields, etc. It is currently work in progress:

- [x] classes
- [x] structs
- [x] interfaces
- [x] fields
- [x] properties

Additional updates included with this pull request:

- use `latest` C# lang version